### PR TITLE
fix: 全盘加密安装的系统，无法通过空间调整扩充空间

### DIFF
--- a/service/diskoperation/filesystems/btrfs.cpp
+++ b/service/diskoperation/filesystems/btrfs.cpp
@@ -41,9 +41,9 @@ std::map<BlockSpecial, BTRFS_Device> btrfs_device_cache;
 
 FS Btrfs::getFilesystemSupport()
 {
-    FS fs( FS_BTRFS );
+    FS fs(FS_BTRFS);
 
-    fs.busy = FS::EXTERNAL ;
+    fs.busy = FS::GPARTED ;
 
     if (!Utils::findProgramInPath("mdir").isEmpty())
     {

--- a/service/diskoperation/partedcore.h
+++ b/service/diskoperation/partedcore.h
@@ -1071,6 +1071,22 @@ private:
      * @return true 关闭成功 false 失败
      */
     bool closeLUKSMap(const QString&devPath,bool &isCLose);
+
+    /**
+    * @brief 增加挂载过滤项
+    * @param devPath:设备路径
+    * @param
+    * @return
+    */
+    void addMountPointExclude(const QString &devPath);
+
+    /**
+    * @brief 删除挂载过滤项
+    * @param devPath:设备路径
+    * @param
+    * @return
+    */
+    void DeleteMountPointExclude(const QString &devPath);
 signals:
     //硬件刷新相关信号
     /**
@@ -1268,6 +1284,7 @@ private:
     int m_usbSig{0};                      //刷新结束后需要发送的信号类型
     bool m_usbArg1{false};                //需要发送的信号bool类型参数
     QString m_usbArg2;                    //需要发送的信号QString类型参数
+    QStringList m_mountPointExclude;      //被操作卸载的分区列表
 };
 
 } // namespace DiskManager


### PR DESCRIPTION
Description: 1.对于界面上被操作卸载的分区，下次刷新设备信息时。不挂载被卸载的分区
             2.对于全盘加密安装的系统已经创建了pv，不需要再次创建。否则会出现创建pv失败

Log:

Bug: https://pms.uniontech.com/bug-view-149047.html