### PR TITLE
fix: btrfs,xfs,exfat格式分区空间调整功能失败

### DIFF
--- a/service/diskoperation/filesystems/btrfs.cpp
+++ b/service/diskoperation/filesystems/btrfs.cpp
@@ -85,8 +85,6 @@ FS Btrfs::getFilesystemSupport()
     fs.online_grow = fs.grow ;
     fs.online_shrink = fs.shrink ;
 
-    m_fsLimits.min_size = 256 * MEBIBYTE;
-
     return fs ;
 }
 
@@ -288,17 +286,6 @@ bool Btrfs::checkRepair(const QString &devpath)
 
 }
 
-FS_Limits Btrfs::getFilesystemLimits(const Partition &partition)
-{
-    return FileSystem::getFilesystemLimits(partition.getPath());
-}
-
-FS_Limits Btrfs::getFilesystemLimits(const QString &path)
-{
-    m_fsLimits = FS_Limits{-1, 10000};
-    return m_fsLimits;
-}
-
 const BTRFS_Device &Btrfs::getCacheEntry(const QString &path)
 {
     std::map<BlockSpecial, BTRFS_Device>::const_iterator bd_iter = btrfs_device_cache.find(BlockSpecial(path));
@@ -413,6 +400,14 @@ double Btrfs::btrfsSizeMaxDelta(QString &str)
     }
     double max_delta = btrfsSize2Double(limit_str) ;
     return max_delta ;
+}
+
+FS_Limits Btrfs::getFilesystemLimits(const Partition &partition)
+{
+    //m_fsLimits.min_size = 256 * MEBIBYTE;
+    m_fsLimits.min_size = -1;
+    m_fsLimits.max_size = -1;
+    return m_fsLimits;
 }
 
 }

--- a/service/diskoperation/filesystems/btrfs.h
+++ b/service/diskoperation/filesystems/btrfs.h
@@ -127,7 +127,6 @@ public:
     */
     bool checkRepair(const QString &devpath) override;
 
-
     /**
     * @brief 获取文件系统限制
     * @param partition：分区信息
@@ -135,13 +134,6 @@ public:
     */
     FS_Limits getFilesystemLimits(const Partition &partition) override;
 
-
-    /**
-    * @brief 获取文件系统限制
-    * @param path：设备路径
-    * @return 文件系统限制信息
-    */
-    FS_Limits getFilesystemLimits(const QString &path) override;
 
 private:
     static const BTRFS_Device & getCacheEntry(const QString &path) ;

--- a/service/diskoperation/filesystems/exfat.cpp
+++ b/service/diskoperation/filesystems/exfat.cpp
@@ -65,6 +65,8 @@ FS ExFat::getFilesystemSupport()
         if (output.contains("exfatprogs version"))
             fs.check = FS::EXTERNAL;
     }
+    fs.grow = FS::NONE;
+    fs.shrink = FS::NONE;
 
     return fs;
 }
@@ -201,18 +203,15 @@ bool DiskManager::ExFat::checkRepair(const DiskManager::Partition &partition)
 bool DiskManager::ExFat::checkRepair(const QString &devpath)
 {
     QString output, error;
-    auto errCode = Utils::executCmd(QString("fsck.exfat -v %1").arg(devpath), output, error);
+    auto errCode = Utils::executCmd(QString("fsck.exfat %1").arg(devpath), output, error);
     return errCode == 0;
 }
 
 FS_Limits DiskManager::ExFat::getFilesystemLimits(const DiskManager::Partition &partition)
 {
-    return FileSystem::getFilesystemLimits(partition);
-}
-
-FS_Limits DiskManager::ExFat::getFilesystemLimits(const QString &path)
-{
-    return FileSystem::getFilesystemLimits(path);
+    m_fsLimits.min_size = -1;
+    m_fsLimits.max_size = -1;
+    return m_fsLimits;
 }
 
 QString DiskManager::ExFat::serial2BlkidUuid(QString serial)

--- a/service/diskoperation/filesystems/exfat.h
+++ b/service/diskoperation/filesystems/exfat.h
@@ -124,14 +124,6 @@ public:
     */
     FS_Limits getFilesystemLimits(const Partition &partition) override;
 
-
-    /**
-    * @brief 获取文件系统限制
-    * @param path：设备路径
-    * @return 文件系统限制信息
-    */
-    FS_Limits getFilesystemLimits(const QString &path) override;
-
 private:
     QString serial2BlkidUuid(QString serial);
     QString randomSerial();

--- a/service/diskoperation/filesystems/xfs.cpp
+++ b/service/diskoperation/filesystems/xfs.cpp
@@ -63,8 +63,7 @@ FS XFS::getFilesystemSupport()
     if (fs.check)
         fs.move = FS::GPARTED;
     fs.online_read = FS::GPARTED;
-    // Official minsize = 16MB, but the smallest xfs_repair can handle is 32MB.
-    m_fsLimits.min_size = 32 * MEBIBYTE;
+
     return fs;
 }
 
@@ -202,14 +201,13 @@ bool XFS::checkRepair(const QString &devpath)
     int exitcode = Utils::executCmd(QString("xfs_repair -v %1").arg(devpath), output, error);
     return exitcode == 0 || error.compare("Unknown error") == 0;
 }
+
 FS_Limits XFS::getFilesystemLimits(const Partition &partition)
 {
-    return getFilesystemLimits(partition.getPath());
-}
-FS_Limits XFS::getFilesystemLimits(const QString &path)
-{
-    Q_UNUSED(path);
-    m_fsLimits = FS_Limits {-1, 0};
+    // Official minsize = 16MB, but the smallest xfs_repair can handle is 32MB.
+    //m_fsLimits.min_size = 32 * MEBIBYTE;
+    m_fsLimits.min_size = -1;
+    m_fsLimits.max_size = -1;
     return m_fsLimits;
 }
 } // namespace DiskManager

--- a/service/diskoperation/filesystems/xfs.h
+++ b/service/diskoperation/filesystems/xfs.h
@@ -100,13 +100,14 @@ public:
      * @param partition：分区信息
      * @return 文件系统限制信息
      */
-    virtual FS_Limits getFilesystemLimits(const Partition &partition) override;
+
     /**
-     * @brief 获取文件系统限制
-     * @param path：设备路径
-     * @return 文件系统限制信息
-     */
-    virtual FS_Limits getFilesystemLimits(const QString &path) override;
+    * @brief 获取文件系统限制
+    * @param partition：分区信息
+    * @return 文件系统限制信息
+    */
+    FS_Limits getFilesystemLimits(const Partition &partition) override;
+
 };
 } // namespace DiskManager
 #endif /* GPARTED_XFS_H */


### PR DESCRIPTION
Description: 空间调整失败的原因：1.btrfs支持增大与缩小、xfs只支持增大、exfat都不支持。界面没有对这三种情况进行区分并使用不同的文案提示
                                 2.这三个文件系统的FS_Limits设置有误

Log: 临时先屏蔽掉这三个文件系统的扩容功能

Bug: https://pms.uniontech.com/bug-view-151491.html