### PR TITLE
fix: 擦除分区，分区挂载点显示异常

### DIFF
--- a/service/diskoperation/partedcore.cpp
+++ b/service/diskoperation/partedcore.cpp
@@ -819,6 +819,9 @@ bool PartedCore::clear(const WipeAction &wipe)
     QPair<bool, QString>pair = tmpMountDevice(mountPath, devPath, fsType, wipe.m_user);
     m_isClear = false;
     qDebug() << __FUNCTION__ << "clear end";
+    if (pair.first) {
+        deleteMountPointExclude(devPath);
+    }
     return sendRefSigAndReturn(pair.first, DISK_SIGNAL_TYPE_CLEAR, pair.first, pair.second);
 }
 
@@ -1041,7 +1044,7 @@ bool PartedCore::mountAndWriteFstab(const QString &mountpath)
     bool success = mountDevice(mountpath, m_curpartition.getPath(),  m_curpartition.m_fstype)  //位置不可交换 利用&&运算特性
                    && writeFstab(m_curpartition.m_uuid, mountpath, type, true);
     qDebug() << __FUNCTION__ << "Permanent mount end";
-    DeleteMountPointExclude(m_curpartition.getPath());
+    deleteMountPointExclude(m_curpartition.getPath());
     return   sendRefSigAndReturn(success);
 }
 
@@ -3862,6 +3865,7 @@ QPair<bool, QString> PartedCore::tmpMountDevice(const QString &mountpath, const 
         return QPair<bool, QString>(false, str);
     }
     QString str = QString("%1:%2:%3").arg("DISK_ERROR").arg(DISK_ERROR::DISK_ERR_NORMAL).arg(devPath);
+
     return QPair<bool, QString>(true, str);
 }
 
@@ -4513,7 +4517,7 @@ void PartedCore::addMountPointExclude(const QString &devPath)
     }
 }
 
-void PartedCore::DeleteMountPointExclude(const QString &devPath)
+void PartedCore::deleteMountPointExclude(const QString &devPath)
 {
     if (m_mountPointExclude.contains(devPath)) {
         m_mountPointExclude.removeOne(devPath);

--- a/service/diskoperation/partedcore.h
+++ b/service/diskoperation/partedcore.h
@@ -1086,7 +1086,7 @@ private:
     * @param
     * @return
     */
-    void DeleteMountPointExclude(const QString &devPath);
+    void deleteMountPointExclude(const QString &devPath);
 signals:
     //硬件刷新相关信号
     /**


### PR DESCRIPTION
Description: 擦除分区后，界面上显示有挂载点。但是实际上该分区并未挂载

Log: 擦除分区时待分区被挂载后将分区从非挂载列表中删除。刷新设备信息时则不会umount该分区

Bug: https://pms.uniontech.com/bug-view-142257.html