### PR TITLE
fix: 新建分区当大小处为空时，点击“+”号按钮，没有提示

### DIFF
--- a/application/widgets/customcontrol/partitionwidget.cpp
+++ b/application/widgets/customcontrol/partitionwidget.cpp
@@ -790,11 +790,12 @@ void PartitionWidget::onSetSliderValue()
         m_partSizeEdit->hideAlertMessage();
     }
 
+    double value = 0;
     if(m_partSizeEdit->text().trimmed().isEmpty()) {
-        return;
+        value = 0;
     }
 
-    double value = m_partSizeEdit->text().toDouble();
+    value = m_partSizeEdit->text().toDouble();
     if (m_partComboBox->currentText() == "MiB")
         value = value / 1024;
     m_block = 1;


### PR DESCRIPTION
Description: 输入大小为空的情况onSetSliderValue直接返回了，导致m_currentEditSize错误

Log: 输入大小为空的情况视为0处理

Bug: https://pms.uniontech.com/bug-view-152433.html