### PR TITLE
fix: 调整ntfs文件系统空间时提示不支持

### DIFF
--- a/basestruct/utils.cpp
+++ b/basestruct/utils.cpp
@@ -705,6 +705,17 @@ void Utils::rmTempDir(QString &dirName)
     }
 }
 
+int Utils::executCmd(const QString &strCmd)
+{
+    QProcess proc;
+    proc.setProgram(strCmd);
+    proc.start(QIODevice::ReadWrite);
+    proc.waitForFinished(-1);
+    int exitcode = proc.exitCode();
+    proc.close();
+    return exitcode;
+}
+
 
 
 

--- a/basestruct/utils.h
+++ b/basestruct/utils.h
@@ -74,6 +74,8 @@ public:
      */
     static int executCmd(const QString &strCmd, QString &outPut, QString &error);
 
+    static int executCmd(const QString &strCmd);
+
     /**
      * @brief 执行外部命令，使用 /bin/bash -c 执行管道命令
      * @param strCmd：命令

--- a/service/diskoperation/filesystems/ntfs.cpp
+++ b/service/diskoperation/filesystems/ntfs.cpp
@@ -182,6 +182,8 @@ bool NTFS::resize(const QString &path, const QString &sizeByte, bool fillPartiti
         size = QString(" -s %1k").arg(sizeByte);
     }
 
+    Utils::executCmd(QString("umount %1").arg(path));
+
     cmd = "ntfsresize --force --force" + size ;
     // Real resize
     cmd = QString("%1 %2").arg(cmd).arg(path);
@@ -220,6 +222,7 @@ FS_Limits NTFS::getFilesystemLimits(const QString &path)
 {
     m_fsLimits = FS_Limits {-1, -1};
     QString cmd, output, error;
+    Utils::executCmd(QString("umount %1").arg(path), output, error);
     cmd = QString("ntfsresize -m -f %1").arg(path);
     if (Utils::executCmd(cmd, output, error) != 0 && error.compare("Unknown error") != 0) {
         return m_fsLimits;

--- a/service/diskoperation/partedcore.cpp
+++ b/service/diskoperation/partedcore.cpp
@@ -3249,15 +3249,16 @@ bool PartedCore::resizeFileSystemImplement(const Partition &partitionOld, const 
 {
     bool fillPartition = false;
     const FS &fsCap = getFileSystem(partitionNew.m_fstype);
+    bool busy = isBusy(partitionOld.m_fstype, partitionOld.getPath());
     FS::Support action = FS::NONE;
     if (partitionNew.getSectorLength() >= partitionOld.getSectorLength()) {
         // grow (always maximises the file system to fill the partition)
         fillPartition = true;
-        action = (partitionOld.m_busy) ? fsCap.online_grow : fsCap.grow;
+        action = busy ? fsCap.online_grow : fsCap.grow;
     } else {
         // shrink
         fillPartition = false;
-        action = (partitionOld.m_busy) ? fsCap.online_shrink : fsCap.shrink;
+        action = busy ? fsCap.online_shrink : fsCap.shrink;
     }
     bool success = false;
     FileSystem *pFilesystem = nullptr;
@@ -3275,7 +3276,7 @@ bool PartedCore::resizeFileSystemImplement(const Partition &partitionOld, const 
     default:
         break;
     }
-
+    deleteMountPointExclude(partitionOld.getPath());
     return success;
 }
 


### PR DESCRIPTION
Description: 1.虽然执行了卸载操作但是再更新设备信息时又会重新挂载上。导致获取的FS_Limit错误
             2.设备被挂载了，识别为分区正忙，执行了在线扩容的逻辑导致提示不支持

Log: 1.在计算FS_Limit时先卸载分区
     2.resize时先卸载分区
     3.判断设备是否busy，不使用设备信息中的值。而是重新根据是否被挂载来判断