### PR TITLE
fix: 外接磁盘新建lvm加密分区，移除外接设备后，文管中仍然显示这些加密的Lvm分区

### DIFF
--- a/application/widgets/createlvwidget.cpp
+++ b/application/widgets/createlvwidget.cpp
@@ -269,9 +269,10 @@ void CreateLVWidget::partInfoShowing()
 {
     auto formateList = DMDbusHandler::instance()->getAllSupportFileSystem();
     formateList.removeOne("linux-swap");
-    if (!DMDbusHandler::instance()->getIsSystemDisk(DMDbusHandler::instance()->getCurVGInfo().m_vgName)) {
-        formateList = DMDbusHandler::instance()->getEncryptionFormate(formateList);
-    }
+    //lvm暂时不支持加密
+//    if (!DMDbusHandler::instance()->getIsSystemDisk(DMDbusHandler::instance()->getCurVGInfo().m_vgName)) {
+//        formateList = DMDbusHandler::instance()->getEncryptionFormate(formateList);
+//    }
 
     //整体垂直布局-三行
     QVBoxLayout *vLayout = new QVBoxLayout(m_partWidget);

--- a/application/widgets/formatedialog.cpp
+++ b/application/widgets/formatedialog.cpp
@@ -143,7 +143,7 @@ void FormateDialog::initUi()
     QStringList fslist = DMDbusHandler::instance()->getAllSupportFileSystem();
     fslist.removeOne("linux-swap");
 //    QStringList formateList = fslist;
-    if (size > 100 && !isSystemDevice) {
+    if (size > 100 && !isSystemDevice && DMDbusHandler::instance()->getCurLevel() != DMDbusHandler::LOGICALVOLUME) {
         fslist = DMDbusHandler::instance()->getEncryptionFormate(fslist);
     }
 


### PR DESCRIPTION
Description: 屏蔽lvm的中的磁盘加密功能，原因：功能不完善

Log:

Bug: https://pms.uniontech.com/bug-view-152927.html