### PR TITLE
fix: 挂载点选择/bin/X11时，一直在挂载中，不能成功

### DIFF
--- a/application/translations/deepin-diskmanager_az.ts
+++ b/application/translations/deepin-diskmanager_az.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>LV adı:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>VG adı:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>LV fayl sistemi:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Geri qaytarın</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>LV məlumatı</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>LV yaradın:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Sonuncu məntiqi tutumu silin</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>LV ölçüsü:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Ayrılmamış</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Adı</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Ölçüsü:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Diski şifrələmək üçün aes-xts-plain64 standart alqoritmindən istifadə edin. Diski yenidən qoşmadan öncə onu şifrələməlisiniz.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Diskin şifrəsini açmaq üçün sm4-xts-plain kriptoqrafiya alqoritmindən istifadə edin. Diski yenidən qoşmadan öncə onun şifrəsini açın. Kriptoqrafiya alqoritmi dəstəkləməyən əməliyyat sistemləri diskin şifrəsini aça bilməyəcək.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Şifrələnəcək tutum 100 MiB-dan böyük olmalıdır</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Şifrənin itirilməsinin qarşısını almaq üçün onun ehtiyyat nüsxəsini etibarlı bir yerdə saxlayın.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
@@ -1687,54 +1687,59 @@ onu formatlayacaq və şifrəsini siləcək.</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>%1 qoşun</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Qoşulma nöqtəsini seçin</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Qoşulma nöqtəsi:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Qoşmaq</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>Qoşulma mümkün olmadı. Seçilmiş qoşulma nöqtəsi boş deyil. Lütfən başqasını seçin!</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OLDU</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Bu qoşulma nöqtəsi altındakı verilənlər itiriləcəkdir, kataloqu başqa yerə qoşmanız xahiş olunur</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Davam edin</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Qoşulma mümkün olmadı. Seçilmiş qoşulma nöqtəsi boş deyil. Lütfən başqasını seçin!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OLDU</translation>
     </message>
 </context>
 <context>
@@ -1815,7 +1820,7 @@ onu formatlayacaq və şifrəsini siləcək.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>%1 ilə bölmələrin sayını artırın. Hər bölmənin üzərinə vuraraq onun adını və fayl sistemini dəyişdirin.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1835,7 +1840,7 @@ onu formatlayacaq və şifrəsini siləcək.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Disk:</translation>
     </message>
@@ -1843,7 +1848,7 @@ onu formatlayacaq və şifrəsini siləcək.</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Fayl sistemi:</translation>
     </message>
@@ -1909,8 +1914,8 @@ onu formatlayacaq və şifrəsini siləcək.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>Uzunluq, həddi keçir</translation>
     </message>
@@ -1925,33 +1930,33 @@ onu formatlayacaq və şifrəsini siləcək.</translation>
         <translation>Diskin şifrəsini açmaq üçün sm4-xts-plain kriptoqrafiya alqoritmindən istifadə edin. Əgər disk şifrələnibsə, qoşmadan öncə onun şifrəsini açmalısınız. Kriptoqrafiya alqoritmi dəstəkləməyən əməliyyat sistemləri diskin şifrəsini aça bilməyəcək.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Yeni bölmələr sayı, icazə verilən həddi keçir</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Şifrələnəcək bölmə 100 MiB-dan böyük olmalıdır</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Yeni bölməni şifrələmək üçün şifrə təyin edin</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Şifrənin itirilməsinin qarşısını almaq üçün onun ehtiyyat nüsxəsini etibarlı bir yerdə saxlayın.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Bir bölmə yaratmaq üçün ən az 52 MB lazımdır</translation>
     </message>

--- a/application/translations/deepin-diskmanager_ca.ts
+++ b/application/translations/deepin-diskmanager_ca.ts
@@ -9,7 +9,7 @@
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="57"/>
         <source>Click %1 to create a logical volume. </source>
-        <translation type="unfinished"/>
+        <translation>Cliqueu a %1 per crear un volum lògic.</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="124"/>
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>Nom del VL:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>Nom del GV:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>Sistema de fitxers del VL:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Reverteix</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>Informació del VL</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>Crea un VL:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Elimina l&apos;últim volum lògic</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>Capacitat del VL:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Sense assignació</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Useu l&apos;algoritme estàndard aes-xts-plain64 per encriptar el disc. Hauríeu de desencriptar-lo abans de tornar-lo a muntar.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Useu l&apos;algoritme criptogràfic sm4-xts-plain d&apos;estat per encriptar el disc. Hauríeu de desencriptar-lo abans de tornar-lo a muntar. Els sistemes operatius que no admeten l&apos;algorisme criptogràfic d&apos;estat no podran desencriptar el disc.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Per encriptar un volum, hauria de ser superior a 100 MiB.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Per evitar perdre la contrasenya, feu-ne una còpia de seguretat i deseu-la correctament!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
@@ -1689,54 +1689,59 @@ Aneu amb compte.</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>Munta %1</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Si us plau, trieu un punt de muntatge.</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Punt de muntatge:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Munta</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>D&apos;acord</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Es perdrien les dades d&apos;aquest punt de muntatge. Monteu el directori a una altra ubicació</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Continua</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>El muntatge ha fallat: el punt de muntatge seleccionat no és buit. Si us plau, seleccioneu-ne un altre!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>D&apos;acord</translation>
     </message>
 </context>
 <context>
@@ -1817,7 +1822,7 @@ Aneu amb compte.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Cliqueu a %1 per augmentar el nombre de particions. Feu clic a cada partició per canviar-ne el nom i el sistema de fitxers.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1837,7 +1842,7 @@ Aneu amb compte.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Disc:</translation>
     </message>
@@ -1845,7 +1850,7 @@ Aneu amb compte.</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Sistema de fitxers:</translation>
     </message>
@@ -1911,8 +1916,8 @@ Aneu amb compte.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>La llargada excedeix el límit.</translation>
     </message>
@@ -1927,33 +1932,33 @@ Aneu amb compte.</translation>
         <translation>Useu l&apos;algoritme criptogràfic sm4-xts-plain d&apos;estat per encriptar el disc. Si està encriptat, hauríeu de desencriptar-lo abans de muntar-lo. Els sistemes operatius que no admeten l&apos;algorisme criptogràfic d&apos;estat no podran desencriptar el disc.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>El número de particions noves supera el límit</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Per encriptar una partició, hauria de ser superior a 100 MiB.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Establiu una contrasenya per encriptar la partició nova.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Per evitar perdre la contrasenya, feu-ne una còpia de seguretat i deseu-la correctament!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Per crear una partició, necessiteu almenys 52 MB</translation>
     </message>

--- a/application/translations/deepin-diskmanager_de.ts
+++ b/application/translations/deepin-diskmanager_de.ts
@@ -9,7 +9,7 @@
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="57"/>
         <source>Click %1 to create a logical volume. </source>
-        <translation type="unfinished"/>
+        <translation>Klicken Sie auf %1, um ein logisches Volumen zu erstellen. </translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="124"/>
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>LV-Name:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>VG-Name:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>LV-Dateisystem:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Rückgängig machen</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>LV-Information</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>LV erstellen:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Letztes logisches Volumen löschen</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>LV-Kapazität:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Nicht zugewiesen</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Um ein Volumen zu verschlüsseln, sollte es größer als 100 MiB sein.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Um den Verlust des Passworts zu vermeiden, sollten Sie Ihr Passwort sichern und sorgfältig aufbewahren!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1691,54 +1691,59 @@ bitte beachten Sie dies sorgfältig</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>%1 einhängen</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Bitte wählen Sie einen Einhängepunkt aus</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Einhängepunkt:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Einhängen</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Die Daten unter diesem Einhängepunkt würden verloren gehen, bitte hängen Sie das Verzeichnis an einem anderen Ort ein</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Fortsetzen</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Einhängen fehlgeschlagen: Der ausgewählte Einhängepunkt ist nicht leer. Bitte wählen Sie einen anderen!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1819,7 +1824,7 @@ bitte beachten Sie dies sorgfältig</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Klicken Sie auf %1, um die Anzahl der Partitionen zu erhöhen. Klicken Sie auf jede Partition, um ihren Namen und ihr Dateisystem zu ändern.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1839,7 +1844,7 @@ bitte beachten Sie dies sorgfältig</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Festplatte:</translation>
     </message>
@@ -1847,7 +1852,7 @@ bitte beachten Sie dies sorgfältig</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Dateisystem:</translation>
     </message>
@@ -1913,8 +1918,8 @@ bitte beachten Sie dies sorgfältig</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>Die Länge überschreitet den Grenzwert</translation>
     </message>
@@ -1929,33 +1934,33 @@ bitte beachten Sie dies sorgfältig</translation>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Die Anzahl der neuen Partitionen überschreitet den Grenzwert</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Um eine Partition zu verschlüsseln, sollte sie größer als 100 MiB sein</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Legen Sie ein Passwort zum Verschlüsseln der neuen Partition fest</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Um den Verlust des Passworts zu vermeiden, sollten Sie Ihr Passwort sichern und sorgfältig aufbewahren!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Zum Erstellen einer Partition benötigen Sie mindestens 52 MB</translation>
     </message>

--- a/application/translations/deepin-diskmanager_en_US.ts
+++ b/application/translations/deepin-diskmanager_en_US.ts
@@ -6,123 +6,123 @@
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="55"/>
         <source>Creating logical volumes on %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating logical volumes on %1</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="57"/>
         <source>Click %1 to create a logical volume. </source>
-        <translation type="unfinished"></translation>
+        <translation>Click %1 to create a logical volume. </translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="124"/>
         <source>VG Information</source>
-        <translation type="unfinished"></translation>
+        <translation>VG Information</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="138"/>
         <source>Capacity:</source>
-        <translation type="unfinished"></translation>
+        <translation>Capacity:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
-        <translation type="unfinished"></translation>
+        <translation>LV name:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
-        <translation type="unfinished"></translation>
+        <translation>VG name:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
-        <translation type="unfinished"></translation>
+        <translation>LV file system:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="242"/>
         <source>Confirm</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Confirm</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="246"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="249"/>
         <source>Revert</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Revert</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
-        <translation type="unfinished"></translation>
+        <translation>LV Information</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
-        <translation type="unfinished"></translation>
+        <translation>Create LV:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete last logical volume</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
-        <translation type="unfinished"></translation>
+        <translation>LV capacity:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Size</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
-        <source>To avoid losing the password, please back up your password and keep it properly!</source>
-        <translation type="unfinished"></translation>
+        <translation>To encrypt a volume, it should be larger than 100 MiB</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <source>To avoid losing the password, please back up your password and keep it properly!</source>
+        <translation>To avoid losing the password, please back up your password and keep it properly!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -130,27 +130,27 @@
     <message>
         <location filename="../widgets/createpartitiontabledialog.cpp" line="30"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/createpartitiontabledialog.cpp" line="37"/>
         <source>No partition table in this disk. Create a new one?</source>
-        <translation type="unfinished"></translation>
+        <translation>No partition table in this disk. Create a new one?</translation>
     </message>
     <message>
         <location filename="../widgets/createpartitiontabledialog.cpp" line="38"/>
         <source>Create</source>
-        <translation type="unfinished"></translation>
+        <translation>Create</translation>
     </message>
     <message>
         <location filename="../widgets/createpartitiontabledialog.cpp" line="43"/>
         <source>The disk has a partition table already. Replace it?</source>
-        <translation type="unfinished"></translation>
+        <translation>The disk has a partition table already. Replace it?</translation>
     </message>
     <message>
         <location filename="../widgets/createpartitiontabledialog.cpp" line="44"/>
         <source>Replace</source>
-        <translation type="unfinished"></translation>
+        <translation>Replace</translation>
     </message>
 </context>
 <context>
@@ -158,17 +158,17 @@
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="75"/>
         <source>Create volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Create volume group</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="85"/>
         <source>Resize</source>
-        <translation type="unfinished"></translation>
+        <translation>Resize</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="109"/>
         <source>Select disks or partitions to create a volume group and set its capacity</source>
-        <translation type="unfinished"></translation>
+        <translation>Select disks or partitions to create a volume group and set its capacity</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="114"/>
@@ -184,166 +184,167 @@
         <location filename="../widgets/createvgwidget.cpp" line="1906"/>
         <location filename="../widgets/createvgwidget.cpp" line="1969"/>
         <source>Capacity selected: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Capacity selected: %1</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="119"/>
         <source>The selected disks will be converted to dynamic disks, and you will not be able to start installed operating systems from the disks.</source>
-        <translation type="unfinished"></translation>
+        <translation>The selected disks will be converted to dynamic disks, and you will not be able to start installed operating systems from the disks.</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="169"/>
         <source>No partitions available</source>
-        <translation type="unfinished"></translation>
+        <translation>No partitions available</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="240"/>
         <source>No disks or partitions available</source>
-        <translation type="unfinished"></translation>
+        <translation>No disks or partitions available</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="274"/>
         <location filename="../widgets/createvgwidget.cpp" line="466"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="277"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="302"/>
         <source>Selected disks/partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Selected disks/partitions</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="339"/>
         <source>Set VG capacity</source>
-        <translation type="unfinished"></translation>
+        <translation>Set VG capacity</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="344"/>
         <source>Auto adjusted to integral multiples of 4 MiB</source>
-        <translation type="unfinished"></translation>
+        <translation>Auto adjusted to integral multiples of 4 MiB</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="432"/>
         <source>Choose one disk or partition at least</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose one disk or partition at least</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="469"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="472"/>
         <source>Done</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Done</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="585"/>
         <source>Resizing space...</source>
-        <translation type="unfinished"></translation>
+        <translation>Resizing space...</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="587"/>
         <source>Creating...</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating...</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="639"/>
         <source>Selected disks and partitions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Selected disks and partitions:</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="682"/>
         <location filename="../widgets/createvgwidget.cpp" line="684"/>
         <source>VG capacity: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>VG capacity: %1</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="689"/>
         <source>VG name: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>VG name: %1</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="790"/>
         <source>No less than the used capacity please</source>
-        <translation type="unfinished"></translation>
+        <translation>No less than the used capacity please</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="795"/>
         <source>No more than the maximum capacity please</source>
-        <translation type="unfinished"></translation>
+        <translation>No more than the maximum capacity please</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="813"/>
         <source>A lot of data exists on %1, </source>
-        <translation type="unfinished"></translation>
+        <translation>A lot of data exists on %1, </translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="814"/>
         <source>which may take a long time to back it up.</source>
-        <translation type="unfinished"></translation>
+        <translation>which may take a long time to back it up.</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="815"/>
         <source>Do you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to continue?</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="816"/>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="817"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="1705"/>
         <location filename="../widgets/createvgwidget.cpp" line="1799"/>
         <source>Adding the disk/partition to a logical volume group 
 will format it and remove its password.</source>
-        <translation type="unfinished"></translation>
+        <translation>Adding the disk/partition to a logical volume group 
+will format it and remove its password.</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="1706"/>
         <location filename="../widgets/createvgwidget.cpp" line="1800"/>
         <location filename="../widgets/createvgwidget.cpp" line="1926"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="1925"/>
         <source>Not enough space to back up data on %1, please clear disk space</source>
-        <translation type="unfinished"></translation>
+        <translation>Not enough space to back up data on %1, please clear disk space</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="2090"/>
         <source>Existing volume group, creation failed. Please retry after reboot.</source>
-        <translation type="unfinished"></translation>
+        <translation>Existing volume group, creation failed. Please retry after reboot.</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="2094"/>
         <source>Failed to create a physical volume. Please refresh Disk Utility and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create a physical volume. Please refresh Disk Utility and try again.</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="2098"/>
         <source>Device input/output error. Please try again after reboot.</source>
-        <translation type="unfinished"></translation>
+        <translation>Device input/output error. Please try again after reboot.</translation>
     </message>
     <message>
         <location filename="../widgets/createvgwidget.cpp" line="2151"/>
         <location filename="../widgets/createvgwidget.cpp" line="2158"/>
         <source>Refreshing the page to reload disks</source>
-        <translation type="unfinished"></translation>
+        <translation>Refreshing the page to reload disks</translation>
     </message>
 </context>
 <context>
@@ -351,32 +352,32 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/cylinderinfowidget.cpp" line="470"/>
         <source>LBA: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>LBA: %1</translation>
     </message>
     <message>
         <location filename="../widgets/cylinderinfowidget.cpp" line="471"/>
         <source>Cyl.: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Cyl.: %1</translation>
     </message>
     <message>
         <location filename="../widgets/cylinderinfowidget.cpp" line="472"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error: %1</translation>
     </message>
     <message>
         <location filename="../widgets/cylinderinfowidget.cpp" line="473"/>
         <source>Cyl. elapsed time: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Cyl. elapsed time: %1</translation>
     </message>
     <message>
         <location filename="../widgets/cylinderinfowidget.cpp" line="473"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>ms</translation>
     </message>
     <message>
         <location filename="../widgets/cylinderinfowidget.cpp" line="474"/>
         <source>Status: Repaired</source>
-        <translation type="unfinished"></translation>
+        <translation>Status: Repaired</translation>
     </message>
 </context>
 <context>
@@ -384,141 +385,141 @@ will format it and remove its password.</source>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="211"/>
         <source>Refreshing data...</source>
-        <translation type="unfinished"></translation>
+        <translation>Refreshing data...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="230"/>
         <source>Initializing data...</source>
-        <translation type="unfinished"></translation>
+        <translation>Initializing data...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="263"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="684"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="775"/>
         <source>Mounting %1 ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Mounting %1 ...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="270"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="691"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="782"/>
         <source>Unmounting %1 ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmounting %1 ...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="309"/>
         <source>Resizing %1 ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Resizing %1 ...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="316"/>
         <source>Creating a new partition...</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating a new partition...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="475"/>
         <source>Deleting %1 ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Deleting %1 ...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="527"/>
         <source>Creating a partition table of %1 ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating a partition table of %1 ...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="529"/>
         <source>Replacing the partition table of %1 ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Replacing the partition table of %1 ...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="651"/>
         <source>Creating...</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="658"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="665"/>
         <source>Deleting...</source>
-        <translation type="unfinished"></translation>
+        <translation>Deleting...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="677"/>
         <source>Resizing space...</source>
-        <translation type="unfinished"></translation>
+        <translation>Resizing space...</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="715"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="874"/>
         <source>AES Encryption</source>
-        <translation type="unfinished"></translation>
+        <translation>AES Encryption</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="717"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="876"/>
         <source>SM4 Encryption</source>
-        <translation type="unfinished"></translation>
+        <translation>SM4 Encryption</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="803"/>
         <source>Failed to encrypt %1, please try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to encrypt %1, please try again!</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="807"/>
         <source>Failed to decrypt %1, please try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to decrypt %1, please try again!</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="811"/>
         <source>%1 failed to close the crypto map</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 failed to close the crypto map</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="818"/>
         <source>Failed to create partitions, please try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create partitions, please try again!</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="822"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="857"/>
         <source>Failed to create %1 file system, please try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create %1 file system, please try again!</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="826"/>
         <source>Failed to submit the request to the kernel</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to submit the request to the kernel</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="830"/>
         <location filename="../partedproxy/dmdbushandler.cpp" line="861"/>
         <source>DBUS parameter error</source>
-        <translation type="unfinished"></translation>
+        <translation>DBUS parameter error</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="834"/>
         <source>Failed to mount %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to mount %1</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="838"/>
         <source>%1 failed to create mounting folders</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 failed to create mounting folders</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="842"/>
         <source>%1 failed to change the owner of mounting folders</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 failed to change the owner of mounting folders</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="846"/>
         <source>Creating partition table failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating partition table failed</translation>
     </message>
     <message>
         <location filename="../partedproxy/dmdbushandler.cpp" line="853"/>
         <source>Failed to create a logical volume, please try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create a logical volume, please try again!</translation>
     </message>
 </context>
 <context>
@@ -526,69 +527,69 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="59"/>
         <source>Enter the password to decrypt the disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the password to decrypt the disk</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="71"/>
         <source>Enter the password to decrypt the volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the password to decrypt the volume group</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="88"/>
         <source>Enter a password </source>
-        <translation type="unfinished"></translation>
+        <translation>Enter a password </translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="93"/>
         <source>Password hint</source>
-        <translation type="unfinished"></translation>
+        <translation>Password hint</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="141"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="146"/>
         <source>Decrypt</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Decrypt</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="174"/>
         <source>Decrypting...</source>
-        <translation type="unfinished"></translation>
+        <translation>Decrypting...</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="218"/>
         <source>Please try again %1 minutes later</source>
-        <translation type="unfinished"></translation>
+        <translation>Please try again %1 minutes later</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="299"/>
         <source>The password cannot be empty</source>
-        <translation type="unfinished"></translation>
+        <translation>The password cannot be empty</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="336"/>
         <source>Decryption failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Decryption failed</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="352"/>
         <source>Password locked, please try again %1 minutes later</source>
-        <translation type="unfinished"></translation>
+        <translation>Password locked, please try again %1 minutes later</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="354"/>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"></translation>
+        <translation>Wrong password, %1 chances left</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="356"/>
         <source>Wrong password, only one chance left</source>
-        <translation type="unfinished"></translation>
+        <translation>Wrong password, only one chance left</translation>
     </message>
 </context>
 <context>
@@ -596,87 +597,89 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="110"/>
         <source>Disk info</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk info</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="117"/>
         <source>Health management</source>
-        <translation type="unfinished"></translation>
+        <translation>Health management</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="123"/>
         <source>Check health</source>
-        <translation type="unfinished"></translation>
+        <translation>Check health</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="129"/>
         <source>Check partition table error</source>
-        <translation type="unfinished"></translation>
+        <translation>Check partition table error</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="135"/>
         <source>Verify or repair bad sectors</source>
-        <translation type="unfinished"></translation>
+        <translation>Verify or repair bad sectors</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="141"/>
         <source>Create partition table</source>
-        <translation type="unfinished"></translation>
+        <translation>Create partition table</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="172"/>
         <source>Delete partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete partition</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="227"/>
         <source>Delete volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete volume group</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="233"/>
         <location filename="../widgets/devicelistwidget.cpp" line="608"/>
         <source>Create logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Create logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="258"/>
         <source>Delete logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="301"/>
         <source>Failed to get hardware information</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to get hardware information</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="301"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Close</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="338"/>
         <source>Please unmount all partitions in the disk first</source>
-        <translation type="unfinished"></translation>
+        <translation>Please unmount all partitions in the disk first</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="338"/>
         <location filename="../widgets/devicelistwidget.cpp" line="579"/>
         <location filename="../widgets/devicelistwidget.cpp" line="632"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="350"/>
         <source>All partitions in this disk will be merged and all data
  will be lost if creating a new partition table,
  please take it carefully</source>
-        <translation type="unfinished"></translation>
+        <translation>All partitions in this disk will be merged and all data
+ will be lost if creating a new partition table,
+ please take it carefully</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="350"/>
         <source>Proceed</source>
-        <translation type="unfinished"></translation>
+        <translation>Proceed</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="350"/>
@@ -686,196 +689,196 @@ will format it and remove its password.</source>
         <location filename="../widgets/devicelistwidget.cpp" line="592"/>
         <location filename="../widgets/devicelistwidget.cpp" line="645"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="376"/>
         <source>No errors found in the partition table</source>
-        <translation type="unfinished"></translation>
+        <translation>No errors found in the partition table</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="389"/>
         <source>Do you want to hide this partition?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to hide this partition?</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="389"/>
         <source>Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>Hide</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="396"/>
         <source>Failed to hide the partition: unable to lock it</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to hide the partition: unable to lock it</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="404"/>
         <source>You can only hide the unmounted partition</source>
-        <translation type="unfinished"></translation>
+        <translation>You can only hide the unmounted partition</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="421"/>
         <source>Do you want to unhide this partition?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to unhide this partition?</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="421"/>
         <source>Unhide</source>
-        <translation type="unfinished"></translation>
+        <translation>Unhide</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="437"/>
         <source>Are you sure you want to delete this partition?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete this partition?</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="437"/>
         <source>You will lose all data in it</source>
-        <translation type="unfinished"></translation>
+        <translation>You will lose all data in it</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="437"/>
         <location filename="../widgets/devicelistwidget.cpp" line="592"/>
         <location filename="../widgets/devicelistwidget.cpp" line="645"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="444"/>
         <source>Failed to delete the partition: unable to lock it</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to delete the partition: unable to lock it</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="459"/>
         <source>Hide the partition successfully</source>
-        <translation type="unfinished"></translation>
+        <translation>Hide the partition successfully</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="464"/>
         <source>Failed to hide the partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to hide the partition</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="474"/>
         <source>Unhide the partition successfully</source>
-        <translation type="unfinished"></translation>
+        <translation>Unhide the partition successfully</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="479"/>
         <source>Failed to unhide the partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to unhide the partition</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="495"/>
         <source>Delete the partition successfully</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete the partition successfully</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="503"/>
         <source>Failed to find the disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to find the disk</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="507"/>
         <source>Failed to get the partition info</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to get the partition info</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="511"/>
         <source>Failed to delete the partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to delete the partition</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="515"/>
         <source>Failed to submit the request to the kernel</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to submit the request to the kernel</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="522"/>
         <source>Failed to delete the partition: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to delete the partition: %1</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="532"/>
         <source>Unmounting successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmounting successful</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="537"/>
         <source>Unmounting failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmounting failed</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="548"/>
         <source>Creating partition table successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating partition table successful</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="552"/>
         <source>Replacing partition table successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Replacing partition table successful</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="560"/>
         <source>Creating partition table failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating partition table failed</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="564"/>
         <source>Replacing partition table failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Replacing partition table failed</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="579"/>
         <source>Unmount all logical volumes in %1 first</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount all logical volumes in %1 first</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="591"/>
         <location filename="../widgets/devicelistwidget.cpp" line="644"/>
         <source>Data cannot be recovered if deleted, please confirm before proceeding</source>
-        <translation type="unfinished"></translation>
+        <translation>Data cannot be recovered if deleted, please confirm before proceeding</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="608"/>
         <source>The disks will be formatted if you create a logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>The disks will be formatted if you create a logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="632"/>
         <source>Unmount %1 first</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount %1 first</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="673"/>
         <source>The logical volume group is busy and cannot be deleted. Please retry after reboot.</source>
-        <translation type="unfinished"></translation>
+        <translation>The logical volume group is busy and cannot be deleted. Please retry after reboot.</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="678"/>
         <location filename="../widgets/devicelistwidget.cpp" line="715"/>
         <source>The logical volume is busy and cannot be deleted. Please retry after reboot.</source>
-        <translation type="unfinished"></translation>
+        <translation>The logical volume is busy and cannot be deleted. Please retry after reboot.</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="683"/>
         <source>Failed to delete the logical volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to delete the logical volume group</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="720"/>
         <source>Failed to delete the logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to delete the logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="830"/>
         <source>Volume Groups</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume Groups</translation>
     </message>
     <message>
         <location filename="../widgets/devicelistwidget.cpp" line="884"/>
         <source>Disks</source>
-        <translation type="unfinished"></translation>
+        <translation>Disks</translation>
     </message>
 </context>
 <context>
@@ -883,116 +886,116 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="56"/>
         <source>Verify or repair bad sectors</source>
-        <translation type="unfinished"></translation>
+        <translation>Verify or repair bad sectors</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="84"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="136"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1224"/>
         <source>Verify:</source>
-        <translation type="unfinished"></translation>
+        <translation>Verify:</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="89"/>
         <source>Cylinders</source>
-        <translation type="unfinished"></translation>
+        <translation>Cylinders</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="90"/>
         <source>Sectors</source>
-        <translation type="unfinished"></translation>
+        <translation>Sectors</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="91"/>
         <source>MB</source>
-        <translation type="unfinished"></translation>
+        <translation>MB</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="132"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="137"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1225"/>
         <source>Method:</source>
-        <translation type="unfinished"></translation>
+        <translation>Method:</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="147"/>
         <source>Rounds</source>
-        <translation type="unfinished"></translation>
+        <translation>Rounds</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="148"/>
         <source>Timeout</source>
-        <translation type="unfinished"></translation>
+        <translation>Timeout</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="190"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>ms</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="223"/>
         <source>Result:</source>
-        <translation type="unfinished"></translation>
+        <translation>Result:</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="247"/>
         <source>Excellent</source>
-        <translation type="unfinished"></translation>
+        <translation>Excellent</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="254"/>
         <source>Damaged</source>
-        <translation type="unfinished"></translation>
+        <translation>Damaged</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="261"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="289"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Exit</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="294"/>
         <source>Reset</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Reset</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="300"/>
         <source>Repair</source>
-        <translation type="unfinished"></translation>
+        <translation>Repair</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="306"/>
         <source>Start Verify</source>
-        <translation type="unfinished"></translation>
+        <translation>Start Verify</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="311"/>
         <source>Stop</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Stop</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="316"/>
         <source>Continue</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="321"/>
         <source>Verify Again</source>
-        <translation type="unfinished"></translation>
+        <translation>Verify Again</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="326"/>
         <source>Done</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Done</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="357"/>
@@ -1003,7 +1006,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1013"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1108"/>
         <source>Time elapsed:</source>
-        <translation type="unfinished"></translation>
+        <translation>Time elapsed:</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="362"/>
@@ -1017,111 +1020,111 @@ will format it and remove its password.</source>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1081"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1114"/>
         <source>Time left:</source>
-        <translation type="unfinished"></translation>
+        <translation>Time left:</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="742"/>
         <source>Verifying cylinder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifying cylinder: %1</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="780"/>
         <source>Verify completed</source>
-        <translation type="unfinished"></translation>
+        <translation>Verify completed</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="802"/>
         <source>Disk verify completed. %1 bad blocks found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk verify completed. %1 bad blocks found.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="802"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="973"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="969"/>
         <source>The verifying disk contains mounted partitions, so you cannot repair it.</source>
-        <translation type="unfinished"></translation>
+        <translation>The verifying disk contains mounted partitions, so you cannot repair it.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="971"/>
         <source>Please unmount partitions and then repair the disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Please unmount partitions and then repair the disk.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="981"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Warning</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="986"/>
         <source>Bad sector repairing cannot recover files,</source>
-        <translation type="unfinished"></translation>
+        <translation>Bad sector repairing cannot recover files,</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="987"/>
         <source>but destroys data on and near bad sectors instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>but destroys data on and near bad sectors instead.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="988"/>
         <source>Please back up all data before repair.</source>
-        <translation type="unfinished"></translation>
+        <translation>Please back up all data before repair.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1002"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1161"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1188"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1003"/>
         <source>Start Repair</source>
-        <translation type="unfinished"></translation>
+        <translation>Start Repair</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1049"/>
         <source>Repairing cylinder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Repairing cylinder: %1</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1086"/>
         <source>Repair completed. Cylinder: %1 repaired.</source>
-        <translation type="unfinished"></translation>
+        <translation>Repair completed. Cylinder: %1 repaired.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1089"/>
         <source>Disk repair completed. %1 bad blocks repaired.</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk repair completed. %1 bad blocks repaired.</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1160"/>
         <source>Verifying for bad sectors, exit now?</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifying for bad sectors, exit now?</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1160"/>
         <source>The verified information will not be reserved</source>
-        <translation type="unfinished"></translation>
+        <translation>The verified information will not be reserved</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1161"/>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1188"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1187"/>
         <source>Repairing bad sectors, exit now?</source>
-        <translation type="unfinished"></translation>
+        <translation>Repairing bad sectors, exit now?</translation>
     </message>
     <message>
         <location filename="../widgets/diskbadsectorsdialog.cpp" line="1187"/>
         <source>The repairing information will not be reserved</source>
-        <translation type="unfinished"></translation>
+        <translation>The repairing information will not be reserved</translation>
     </message>
 </context>
 <context>
@@ -1129,89 +1132,89 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="66"/>
         <source>Check Health</source>
-        <translation type="unfinished"></translation>
+        <translation>Check Health</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="98"/>
         <source>Serial number</source>
-        <translation type="unfinished"></translation>
+        <translation>Serial number</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="108"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Storage</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="130"/>
         <source>Health Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Health Status</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="145"/>
         <source>Good</source>
-        <translation type="unfinished"></translation>
+        <translation>Good</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="151"/>
         <source>Damaged</source>
-        <translation type="unfinished"></translation>
+        <translation>Damaged</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="157"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="176"/>
         <source>Temperature</source>
-        <translation type="unfinished"></translation>
+        <translation>Temperature</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="241"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="422"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="242"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="422"/>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Status</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="243"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="422"/>
         <source>Current</source>
-        <translation type="unfinished"></translation>
+        <translation>Current</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="244"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="422"/>
         <source>Worst</source>
-        <translation type="unfinished"></translation>
+        <translation>Worst</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="245"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="423"/>
         <source>Threshold</source>
-        <translation type="unfinished"></translation>
+        <translation>Threshold</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="246"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="423"/>
         <source>Raw Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Raw Value</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="247"/>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="423"/>
         <source>Attribute name</source>
-        <translation type="unfinished"></translation>
+        <translation>Attribute name</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="344"/>
         <source>Status: (G: Good | W: Warning | D: Damaged | U: Unknown)</source>
-        <translation type="unfinished"></translation>
+        <translation>Status: (G: Good | W: Warning | D: Damaged | U: Unknown)</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="348"/>
@@ -1219,37 +1222,37 @@ will format it and remove its password.</source>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="454"/>
         <source>Export</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Export</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="389"/>
         <source>Save File</source>
-        <translation type="unfinished"></translation>
+        <translation>Save File</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="389"/>
         <source>Text files (*.txt)</source>
-        <translation type="unfinished"></translation>
+        <translation>Text files (*.txt)</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="403"/>
         <source>Wrong path</source>
-        <translation type="unfinished"></translation>
+        <translation>Wrong path</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="411"/>
         <source>You do not have permission to access this path</source>
-        <translation type="unfinished"></translation>
+        <translation>You do not have permission to access this path</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="441"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Export successful</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="444"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Export failed</translation>
     </message>
 </context>
 <context>
@@ -1257,77 +1260,77 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="56"/>
         <source>Disk Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk Info</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="67"/>
         <source>Model:</source>
-        <translation type="unfinished"></translation>
+        <translation>Model:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="67"/>
         <source>Vendor:</source>
-        <translation type="unfinished"></translation>
+        <translation>Vendor:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="67"/>
         <source>Media Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Media Type:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="67"/>
         <source>Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Size:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="68"/>
         <source>Rotation Rate:</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotation Rate:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="68"/>
         <source>Interface:</source>
-        <translation type="unfinished"></translation>
+        <translation>Interface:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="68"/>
         <source>Serial Number:</source>
-        <translation type="unfinished"></translation>
+        <translation>Serial Number:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="68"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Version:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="69"/>
         <source>Capabilities:</source>
-        <translation type="unfinished"></translation>
+        <translation>Capabilities:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="69"/>
         <source>Description:</source>
-        <translation type="unfinished"></translation>
+        <translation>Description:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="69"/>
         <source>Power On Hours:</source>
-        <translation type="unfinished"></translation>
+        <translation>Power On Hours:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="70"/>
         <source>Power Cycle Count:</source>
-        <translation type="unfinished"></translation>
+        <translation>Power Cycle Count:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="70"/>
         <source>Firmware Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Firmware Version:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="70"/>
         <source>Speed:</source>
-        <translation type="unfinished"></translation>
+        <translation>Speed:</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="73"/>
@@ -1338,7 +1341,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="78"/>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="79"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="120"/>
@@ -1346,37 +1349,37 @@ will format it and remove its password.</source>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="212"/>
         <source>Export</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Export</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="151"/>
         <source>Save File</source>
-        <translation type="unfinished"></translation>
+        <translation>Save File</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="151"/>
         <source>Text files (*.txt)</source>
-        <translation type="unfinished"></translation>
+        <translation>Text files (*.txt)</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="166"/>
         <source>Wrong path</source>
-        <translation type="unfinished"></translation>
+        <translation>Wrong path</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="174"/>
         <source>You do not have permission to access this path</source>
-        <translation type="unfinished"></translation>
+        <translation>You do not have permission to access this path</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="199"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Export successful</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="202"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Export failed</translation>
     </message>
 </context>
 <context>
@@ -1384,128 +1387,128 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="103"/>
         <source>Wipe %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Wipe %1</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="111"/>
         <source>It will erase all data on this disk, which will not be recovered</source>
-        <translation type="unfinished"></translation>
+        <translation>It will erase all data on this disk, which will not be recovered</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="122"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="133"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="135"/>
         <source>File system:</source>
-        <translation type="unfinished"></translation>
+        <translation>File system:</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="165"/>
         <source>AES Encryption</source>
-        <translation type="unfinished"></translation>
+        <translation>AES Encryption</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="168"/>
         <source>SM4 Encryption</source>
-        <translation type="unfinished"></translation>
+        <translation>SM4 Encryption</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="182"/>
         <source>Security:</source>
-        <translation type="unfinished"></translation>
+        <translation>Security:</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="195"/>
         <location filename="../widgets/formatedialog.cpp" line="199"/>
         <source>Fast</source>
-        <translation type="unfinished"></translation>
+        <translation>Fast</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="195"/>
         <location filename="../widgets/formatedialog.cpp" line="199"/>
         <source>Secure</source>
-        <translation type="unfinished"></translation>
+        <translation>Secure</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="199"/>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Advanced</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="213"/>
         <location filename="../widgets/formatedialog.cpp" line="505"/>
         <source>It only deletes the partition info without erasing the files on the disk. Disk recovery tools may recover the files at a certain probability.</source>
-        <translation type="unfinished"></translation>
+        <translation>It only deletes the partition info without erasing the files on the disk. Disk recovery tools may recover the files at a certain probability.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="219"/>
         <source>Wiping method:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wiping method:</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="231"/>
         <source>DoD 5220.22-M, 7 passes</source>
-        <translation type="unfinished"></translation>
+        <translation>DoD 5220.22-M, 7 passes</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="231"/>
         <source>Gutmann, 35 passes</source>
-        <translation type="unfinished"></translation>
+        <translation>Gutmann, 35 passes</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="292"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="296"/>
         <source>Wipe</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Wipe</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="343"/>
         <source>Failed to find the disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to find the disk</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="346"/>
         <source>The action cannot be undone, please proceed with caution</source>
-        <translation type="unfinished"></translation>
+        <translation>The action cannot be undone, please proceed with caution</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="348"/>
         <source>LV name:</source>
-        <translation type="unfinished"></translation>
+        <translation>LV name:</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="352"/>
         <source>LV name</source>
-        <translation type="unfinished"></translation>
+        <translation>LV name</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="354"/>
         <source>LV file system:</source>
-        <translation type="unfinished"></translation>
+        <translation>LV file system:</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="356"/>
         <location filename="../widgets/formatedialog.cpp" line="555"/>
         <source>You may be able to recover files after the wipe.</source>
-        <translation type="unfinished"></translation>
+        <translation>You may be able to recover files after the wipe.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="359"/>
         <source>Failed to submit the request to the kernel</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to submit the request to the kernel</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="407"/>
@@ -1513,58 +1516,58 @@ will format it and remove its password.</source>
         <location filename="../widgets/formatedialog.cpp" line="440"/>
         <location filename="../widgets/formatedialog.cpp" line="452"/>
         <source>The length exceeds the limit</source>
-        <translation type="unfinished"></translation>
+        <translation>The length exceeds the limit</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="470"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="480"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="520"/>
         <source>It is a one-time secure wipe that complies with NIST 800-88 and writes 0, 1, and random data to the entire disk once. You will not be able to recover files, and the process will be slow.</source>
-        <translation type="unfinished"></translation>
+        <translation>It is a one-time secure wipe that complies with NIST 800-88 and writes 0, 1, and random data to the entire disk once. You will not be able to recover files, and the process will be slow.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="535"/>
         <source>It writes 0, 1, and random data to the entire disk several times. You can set the number of times to erase disks and overwrite data, but the process will be very slow.</source>
-        <translation type="unfinished"></translation>
+        <translation>It writes 0, 1, and random data to the entire disk several times. You can set the number of times to erase disks and overwrite data, but the process will be very slow.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="568"/>
         <source>You will not be able to recover files after the wipe, and the process will be slow.</source>
-        <translation type="unfinished"></translation>
+        <translation>You will not be able to recover files after the wipe, and the process will be slow.</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="640"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
-        <translation type="unfinished"></translation>
+        <translation>To avoid losing the password, please back up your password and keep it properly!</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="641"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="718"/>
         <source>Wiping %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Wiping %1</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="746"/>
         <source>&quot;%1&quot; wiped</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; wiped</translation>
     </message>
     <message>
         <location filename="../widgets/formatedialog.cpp" line="753"/>
         <source>Failed to wipe %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to wipe %1</translation>
     </message>
 </context>
 <context>
@@ -1575,17 +1578,17 @@ will format it and remove its password.</source>
         <location filename="../widgets/infoshowwidget.cpp" line="385"/>
         <location filename="../widgets/infoshowwidget.cpp" line="582"/>
         <source>Mount point:</source>
-        <translation type="unfinished"></translation>
+        <translation>Mount point:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="147"/>
         <source>Free:</source>
-        <translation type="unfinished"></translation>
+        <translation>Free:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="154"/>
         <source>Used:</source>
-        <translation type="unfinished"></translation>
+        <translation>Used:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="161"/>
@@ -1594,61 +1597,61 @@ will format it and remove its password.</source>
         <location filename="../widgets/infoshowwidget.cpp" line="505"/>
         <location filename="../widgets/infoshowwidget.cpp" line="583"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Type:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="169"/>
         <source>Capacity:</source>
-        <translation type="unfinished"></translation>
+        <translation>Capacity:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="175"/>
         <location filename="../widgets/infoshowwidget.cpp" line="246"/>
         <location filename="../widgets/infoshowwidget.cpp" line="387"/>
         <source>Volume label:</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume label:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="323"/>
         <source>Path:</source>
-        <translation type="unfinished"></translation>
+        <translation>Path:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="324"/>
         <source>Disk type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk type:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="325"/>
         <source>Interface:</source>
-        <translation type="unfinished"></translation>
+        <translation>Interface:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="504"/>
         <source>LV count:</source>
-        <translation type="unfinished"></translation>
+        <translation>LV count:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="506"/>
         <source>VG name:</source>
-        <translation type="unfinished"></translation>
+        <translation>VG name:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="511"/>
         <location filename="../widgets/infoshowwidget.cpp" line="514"/>
         <source>Volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume group</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="584"/>
         <source>Volume name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume name:</translation>
     </message>
     <message>
         <location filename="../widgets/infoshowwidget.cpp" line="589"/>
         <location filename="../widgets/infoshowwidget.cpp" line="592"/>
         <source>Logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Logical volume</translation>
     </message>
 </context>
 <context>
@@ -1656,7 +1659,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/infotopframe.cpp" line="68"/>
         <source>Capacity</source>
-        <translation type="unfinished"></translation>
+        <translation>Capacity</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/infotopframe.cpp" line="147"/>
@@ -1664,17 +1667,17 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/infotopframe.cpp" line="169"/>
         <location filename="../widgets/customcontrol/infotopframe.cpp" line="224"/>
         <source>File system</source>
-        <translation type="unfinished"></translation>
+        <translation>File system</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/infotopframe.cpp" line="181"/>
         <source>%1 partition table</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 partition table</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/infotopframe.cpp" line="200"/>
         <source>Volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume group</translation>
     </message>
 </context>
 <context>
@@ -1682,60 +1685,70 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/mainwindow.cpp" line="121"/>
         <source>Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>Refresh</translation>
     </message>
 </context>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Mount %1</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose a mount point please</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
+        <translation>Mount point:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="92"/>
+        <source>Please select /mnt or /media, or its subdirectories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
-        <translation type="unfinished"></translation>
+        <translation>Mount</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
-        <translation type="unfinished"></translation>
+        <translation>The data under this mount point would be lost, please mount the directory to another location</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Mounting failed: The selected mount point is not empty. Please select another one!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1743,7 +1756,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partchartshowing.cpp" line="122"/>
         <source>Unallocated</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
 </context>
 <context>
@@ -1751,22 +1764,22 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/partitiondialog.cpp" line="48"/>
         <source>Partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Partition %1</translation>
     </message>
     <message>
         <location filename="../widgets/partitiondialog.cpp" line="50"/>
         <source>It will increase the number of partitions on the disk</source>
-        <translation type="unfinished"></translation>
+        <translation>It will increase the number of partitions on the disk</translation>
     </message>
     <message>
         <location filename="../widgets/partitiondialog.cpp" line="57"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/partitiondialog.cpp" line="58"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm</translation>
     </message>
 </context>
 <context>
@@ -1774,7 +1787,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitioninfowidget.cpp" line="256"/>
         <source>Unallocated</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
 </context>
 <context>
@@ -1782,28 +1795,28 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="59"/>
         <source>Errors in Partition Table</source>
-        <translation type="unfinished"></translation>
+        <translation>Errors in Partition Table</translation>
     </message>
     <message>
         <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="74"/>
         <source>The partition table of disk %1 has below errors:</source>
-        <translation type="unfinished"></translation>
+        <translation>The partition table of disk %1 has below errors:</translation>
     </message>
     <message>
         <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="111"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="120"/>
         <source>Partition table entries are not in disk order</source>
-        <translation type="unfinished"></translation>
+        <translation>Partition table entries are not in disk order</translation>
     </message>
     <message>
         <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="132"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1811,150 +1824,150 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="59"/>
         <source>Partitioning %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitioning %1</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"></translation>
+        <translation>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
         <source>Disk Information</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk Information</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="142"/>
         <source>Capacity:</source>
-        <translation type="unfinished"></translation>
+        <translation>Capacity:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="152"/>
         <source>Partition selected:</source>
-        <translation type="unfinished"></translation>
+        <translation>Partition selected:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
-        <translation type="unfinished"></translation>
+        <translation>File system:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="246"/>
         <source>Confirm</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Confirm</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="250"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="253"/>
         <source>Revert</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Revert</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="283"/>
         <source>Partition Information</source>
-        <translation type="unfinished"></translation>
+        <translation>Partition Information</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="295"/>
         <source>Number of partitions:</source>
-        <translation type="unfinished"></translation>
+        <translation>Number of partitions:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="306"/>
         <source>Delete last partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete last partition</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="316"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="344"/>
         <source>Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Size:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="481"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="594"/>
         <source>Unallocated</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="504"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="505"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Size</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
-        <translation type="unfinished"></translation>
+        <translation>The length exceeds the limit</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="723"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. If it is encrypted, you should decrypt it before mounting.</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the aes-xts-plain64 standard algorithm to encrypt the disk. If it is encrypted, you should decrypt it before mounting.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="729"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. If it is encrypted, you should decrypt it before mounting. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. If it is encrypted, you should decrypt it before mounting. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
-        <translation type="unfinished"></translation>
+        <translation>The number of new partitions exceeds the limit</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
-        <translation type="unfinished"></translation>
+        <translation>To encrypt a partition, it should be larger than 100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
-        <source>To avoid losing the password, please back up your password and keep it properly!</source>
-        <translation type="unfinished"></translation>
+        <translation>Set a password to encrypt the new partition</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <source>To avoid losing the password, please back up your password and keep it properly!</source>
+        <translation>To avoid losing the password, please back up your password and keep it properly!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
-        <translation type="unfinished"></translation>
+        <translation>To create a partition, you need at least 52 MB</translation>
     </message>
 </context>
 <context>
@@ -1963,81 +1976,81 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="73"/>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="178"/>
         <source>Set a password to encrypt %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Set a password to encrypt %1</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="77"/>
         <source>The password cannot be reset or retrieved online</source>
-        <translation type="unfinished"></translation>
+        <translation>The password cannot be reset or retrieved online</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="81"/>
         <source>Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="86"/>
         <source>Repeat password</source>
-        <translation type="unfinished"></translation>
+        <translation>Repeat password</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="91"/>
         <source>Password hint</source>
-        <translation type="unfinished"></translation>
+        <translation>Password hint</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="95"/>
         <source>(Recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Recommended)</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="105"/>
         <source>Enter a password </source>
-        <translation type="unfinished"></translation>
+        <translation>Enter a password </translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="111"/>
         <source>Enter the password again</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the password again</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="117"/>
         <source>Enter a password hint</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter a password hint</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="160"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="161"/>
         <source>Confirm</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Confirm</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="206"/>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="220"/>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="254"/>
         <source>The password exceeds the maximum length</source>
-        <translation type="unfinished"></translation>
+        <translation>The password exceeds the maximum length</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="247"/>
         <source>The password cannot be empty</source>
-        <translation type="unfinished"></translation>
+        <translation>The password cannot be empty</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="261"/>
         <source>Passwords do not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwords do not match</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="268"/>
         <source>The password hint should differ from the password</source>
-        <translation type="unfinished"></translation>
+        <translation>The password hint should differ from the password</translation>
     </message>
 </context>
 <context>
@@ -2045,12 +2058,12 @@ will format it and remove its password.</source>
     <message>
         <location filename="../main.cpp" line="95"/>
         <source>Disk Utility</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk Utility</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="103"/>
         <source>Disk Utility is a disk management tool for creating, reorganizing and formatting partitions.</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk Utility is a disk management tool for creating, reorganizing and formatting partitions.</translation>
     </message>
 </context>
 <context>
@@ -2058,69 +2071,69 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="73"/>
         <source>Are you sure you want to delete the physical volume?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the physical volume?</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="79"/>
         <source>To prevent data loss, back up data in the physical volume before deleting it</source>
-        <translation type="unfinished"></translation>
+        <translation>To prevent data loss, back up data in the physical volume before deleting it</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="86"/>
         <source>Cancel</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="93"/>
         <source>Delete</source>
         <comment>button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="124"/>
         <source>Deleting...</source>
-        <translation type="unfinished"></translation>
+        <translation>Deleting...</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="231"/>
         <source>A lot of data exists on %1, </source>
-        <translation type="unfinished"></translation>
+        <translation>A lot of data exists on %1, </translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="232"/>
         <source>which may take a long time to back it up.</source>
-        <translation type="unfinished"></translation>
+        <translation>which may take a long time to back it up.</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="233"/>
         <source>Do you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to continue?</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="234"/>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="235"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="247"/>
         <source>Not enough space to back up data on %1, please delete the logical volume first</source>
-        <translation type="unfinished"></translation>
+        <translation>Not enough space to back up data on %1, please delete the logical volume first</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="248"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/removepvwidget.cpp" line="275"/>
         <source>Failed to delete the physical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to delete the physical volume</translation>
     </message>
 </context>
 <context>
@@ -2128,28 +2141,28 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="52"/>
         <source>It will resize the partitions on the disk</source>
-        <translation type="unfinished"></translation>
+        <translation>It will resize the partitions on the disk</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="72"/>
         <source>New capacity:</source>
-        <translation type="unfinished"></translation>
+        <translation>New capacity:</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="95"/>
         <source>Auto adjusted to integral multiples of 4 MiB</source>
-        <translation type="unfinished"></translation>
+        <translation>Auto adjusted to integral multiples of 4 MiB</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="108"/>
         <location filename="../widgets/resizedialog.cpp" line="113"/>
         <source>Resize %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Resize %1</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="115"/>
         <source>It will resize the logical volume space</source>
-        <translation type="unfinished"></translation>
+        <translation>It will resize the logical volume space</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="121"/>
@@ -2157,12 +2170,12 @@ will format it and remove its password.</source>
         <location filename="../widgets/resizedialog.cpp" line="344"/>
         <location filename="../widgets/resizedialog.cpp" line="347"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="122"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="149"/>
@@ -2170,12 +2183,12 @@ will format it and remove its password.</source>
         <location filename="../widgets/resizedialog.cpp" line="211"/>
         <location filename="../widgets/resizedialog.cpp" line="320"/>
         <source>No more than the maximum capacity please</source>
-        <translation type="unfinished"></translation>
+        <translation>No more than the maximum capacity please</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="227"/>
         <source>The file system does not support shrinking space</source>
-        <translation type="unfinished"></translation>
+        <translation>The file system does not support shrinking space</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="227"/>
@@ -2184,38 +2197,38 @@ will format it and remove its password.</source>
         <location filename="../widgets/resizedialog.cpp" line="347"/>
         <location filename="../widgets/resizedialog.cpp" line="383"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="241"/>
         <location filename="../widgets/resizedialog.cpp" line="302"/>
         <source>No less than the used capacity please</source>
-        <translation type="unfinished"></translation>
+        <translation>No less than the used capacity please</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="248"/>
         <source>To prevent data loss, back up data before shrinking it</source>
-        <translation type="unfinished"></translation>
+        <translation>To prevent data loss, back up data before shrinking it</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="334"/>
         <source>Unmount it before shrinking its space</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount it before shrinking its space</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="344"/>
         <source>The current device has been mounted and will be unmounted automatically. Please back up data in it to prevent data loss</source>
-        <translation type="unfinished"></translation>
+        <translation>The current device has been mounted and will be unmounted automatically. Please back up data in it to prevent data loss</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="347"/>
         <source>To prevent data loss, back up data in the logical volume before shrinking it</source>
-        <translation type="unfinished"></translation>
+        <translation>To prevent data loss, back up data in the logical volume before shrinking it</translation>
     </message>
     <message>
         <location filename="../widgets/resizedialog.cpp" line="383"/>
         <source>The file system does not support space adjustment</source>
-        <translation type="unfinished"></translation>
+        <translation>The file system does not support space adjustment</translation>
     </message>
 </context>
 <context>
@@ -2224,7 +2237,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="278"/>
         <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="362"/>
         <source> Capacity:</source>
-        <translation type="unfinished"></translation>
+        <translation> Capacity:</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="318"/>
@@ -2232,7 +2245,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="402"/>
         <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="405"/>
         <source>Used:</source>
-        <translation type="unfinished"></translation>
+        <translation>Used:</translation>
     </message>
 </context>
 <context>
@@ -2240,66 +2253,66 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="54"/>
         <source>Partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Partition</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="55"/>
         <source>Wipe</source>
-        <translation type="unfinished"></translation>
+        <translation>Wipe</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="56"/>
         <source>Mount</source>
-        <translation type="unfinished"></translation>
+        <translation>Mount</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="57"/>
         <source>Unmount</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="58"/>
         <location filename="../widgets/titlewidget.cpp" line="79"/>
         <location filename="../widgets/titlewidget.cpp" line="83"/>
         <source>Resize</source>
-        <translation type="unfinished"></translation>
+        <translation>Resize</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="59"/>
         <location filename="../widgets/titlewidget.cpp" line="462"/>
         <source>Create volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Create volume group</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="63"/>
         <source>Delete volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete volume group</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="67"/>
         <source>Delete logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="71"/>
         <source>Delete physical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete physical volume</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="75"/>
         <location filename="../widgets/titlewidget.cpp" line="359"/>
         <source>Create logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Create logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="193"/>
         <source>Cannot recognize its partition table</source>
-        <translation type="unfinished"></translation>
+        <translation>Cannot recognize its partition table</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="239"/>
         <source>Unable to mount the device: no file system is found, or the file system is not supported</source>
-        <translation type="unfinished"></translation>
+        <translation>Unable to mount the device: no file system is found, or the file system is not supported</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="240"/>
@@ -2311,59 +2324,60 @@ will format it and remove its password.</source>
         <location filename="../widgets/titlewidget.cpp" line="483"/>
         <location filename="../widgets/titlewidget.cpp" line="596"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="339"/>
         <location filename="../widgets/titlewidget.cpp" line="433"/>
         <source>The file system does not support space adjustment</source>
-        <translation type="unfinished"></translation>
+        <translation>The file system does not support space adjustment</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="359"/>
         <source>The disks will be formatted if you create a logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>The disks will be formatted if you create a logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="383"/>
         <location filename="../widgets/titlewidget.cpp" line="417"/>
         <location filename="../widgets/titlewidget.cpp" line="596"/>
         <source>Unmount %1 first</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount %1 first</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="395"/>
         <location filename="../widgets/titlewidget.cpp" line="495"/>
         <source>Data cannot be recovered if deleted, please confirm before proceeding</source>
-        <translation type="unfinished"></translation>
+        <translation>Data cannot be recovered if deleted, please confirm before proceeding</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="396"/>
         <location filename="../widgets/titlewidget.cpp" line="496"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="396"/>
         <location filename="../widgets/titlewidget.cpp" line="496"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="446"/>
         <source>To ensure the normal use of system backup and restore, 
 rootA and rootB should be resized to the same value</source>
-        <translation type="unfinished"></translation>
+        <translation>To ensure the normal use of system backup and restore, 
+rootA and rootB should be resized to the same value</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="462"/>
         <source>The disks will be formatted if you create a volume group</source>
-        <translation type="unfinished"></translation>
+        <translation>The disks will be formatted if you create a volume group</translation>
     </message>
     <message>
         <location filename="../widgets/titlewidget.cpp" line="483"/>
         <source>Unmount all logical volumes in %1 first</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount all logical volumes in %1 first</translation>
     </message>
 </context>
 <context>
@@ -2371,29 +2385,29 @@ rootA and rootB should be resized to the same value</source>
     <message>
         <location filename="../widgets/unmountdialog.cpp" line="48"/>
         <source>Make sure there are no programs running on the disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Make sure there are no programs running on the disk</translation>
     </message>
     <message>
         <location filename="../widgets/unmountdialog.cpp" line="57"/>
         <location filename="../widgets/unmountdialog.cpp" line="60"/>
         <location filename="../widgets/unmountdialog.cpp" line="65"/>
         <source>Unmount %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount %1</translation>
     </message>
     <message>
         <location filename="../widgets/unmountdialog.cpp" line="62"/>
         <source>Make sure there are no programs running on the logical volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Make sure there are no programs running on the logical volume</translation>
     </message>
     <message>
         <location filename="../widgets/unmountdialog.cpp" line="68"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/unmountdialog.cpp" line="69"/>
         <source>Unmount</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount</translation>
     </message>
 </context>
 <context>
@@ -2401,22 +2415,22 @@ rootA and rootB should be resized to the same value</source>
     <message>
         <location filename="../widgets/unmountwarningdialog.cpp" line="53"/>
         <source>Unmounting system disk may result in system crash</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmounting system disk may result in system crash</translation>
     </message>
     <message>
         <location filename="../widgets/unmountwarningdialog.cpp" line="59"/>
         <source>I will take the risks that may arise</source>
-        <translation type="unfinished"></translation>
+        <translation>I will take the risks that may arise</translation>
     </message>
     <message>
         <location filename="../widgets/unmountwarningdialog.cpp" line="78"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../widgets/unmountwarningdialog.cpp" line="79"/>
         <source>Unmount</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmount</translation>
     </message>
 </context>
 <context>
@@ -2425,7 +2439,7 @@ rootA and rootB should be resized to the same value</source>
         <location filename="../widgets/customcontrol/vgsizeinfowidget.cpp" line="544"/>
         <location filename="../widgets/customcontrol/vgsizeinfowidget.cpp" line="613"/>
         <source>Unallocated</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
 </context>
 </TS>

--- a/application/translations/deepin-diskmanager_fi.ts
+++ b/application/translations/deepin-diskmanager_fi.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>LV nimi:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>VG nimi:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>LV-tiedostojärjestelmä:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Palaa</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>LV tiedot</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>Luo LV:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Poista viimeinen looginen asema</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>LV-kapasiteetti:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Varaamaton</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Käytä aes-xts-plain64 standardin algoritmia levyn salaamiseen. Sinun tulee purkaa sen salaus ennen kuin asennat sen uudelleen.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Käytä sm4-xts-plain state algoritmia levyn salaamiseen. Sinun tulee purkaa sen salaus ennen kuin asennat sen uudelleen. Käyttöjärjestelmät, jotka eivät tue salausalgoritmia, eivät pysty purkamaan levyn salausta.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Levyn salaamiseksi sen tulee olla suurempi kuin 100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Jotta et menetä salasanaa, varmuuskopioi salasanasi ja säilytä se hyvin!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1688,54 +1688,59 @@ Ole huolellinen.</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>Liitos %1</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Valitse liitospiste</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Liitospiste:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Liitos</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>Yhdistäminen epäonnistui: Valittu liitospiste ei ole tyhjä. Valitse toinen!</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Tämän liittymispisteen tiedot menetetään, liitä hakemisto toiseen sijaintiin</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Jatka</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Yhdistäminen epäonnistui: Valittu liitospiste ei ole tyhjä. Valitse toinen!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1816,7 +1821,7 @@ Ole huolellinen.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Napsauta %1 lisätäksesi osioiden määrää. Napsauta jokaista osiota ja muuta sen nimeä tai tiedostojärjestelmää</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1836,7 +1841,7 @@ Ole huolellinen.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Levy:</translation>
     </message>
@@ -1844,7 +1849,7 @@ Ole huolellinen.</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Tiedostojärjestelmä:</translation>
     </message>
@@ -1910,8 +1915,8 @@ Ole huolellinen.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>Pituus ylittää rajan</translation>
     </message>
@@ -1926,33 +1931,33 @@ Ole huolellinen.</translation>
         <translation>Käytä sm4-xts-plain state algoritmia levyn salaamiseen. Jos se on salattu, sinun tulee purkaa sen salaus ennen asennusta. Käyttöjärjestelmät, jotka eivät tue salausalgoritmia, eivät pysty purkamaan levyn salausta.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Uusien osioiden määrä ylittää rajan</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Osion salaamiseksi sen tulee olla suurempi kuin 100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Aseta salasana uuden osion salaamiseksi</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Jotta et menetä salasanaa, varmuuskopioi salasanasi ja säilytä se hyvin!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Osion luomiseen tarvitaan vähintään 52 Mt</translation>
     </message>

--- a/application/translations/deepin-diskmanager_hu.ts
+++ b/application/translations/deepin-diskmanager_hu.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>Logikai kötet neve:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>Kötetcsoport neve:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>Logikai kötet fájlrendszere:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Visszavonás</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>Logikai kötet információi</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>Logikai kötet létrehozása:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Az utolsó logikai kötet törlése </translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>Logikai kötet kapacitása:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Felhasználatlan</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Használja az aes-xts-plain64 szabványos algoritmust a lemez titkosításához. Mielőtt újra felcsatolná, vissza kell fejtenie azt.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Használja az sm4-xts-plain state kriptográfiai algoritmust a lemez titkosításához. Mielőtt újra felcsatolná, vissza kell fejtenie azt. Azok az operációs rendszerek, amelyek nem támogatják az állapotkriptográfiai algoritmust, nem tudják visszafejteni a lemezt.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>A kötet titkosításához, annak méretének 100 MB-nál nagyobbnak kell lennie</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>A jelszó elvesztésének elkerülése érdekében kérjük készítsen biztonsági másolatot jelszaváról, és őrizze meg azt megfelelően!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1689,54 +1689,59 @@ kérjük legyen óvatos</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>%1 csatolása</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Kérjük válasszon csatolási pontot</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Csatolási pont:  </translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Csatolás</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>A csatolás sikertelen: A kiválasztott csatolási pont nem üres. Kérjük válasszon másikat!</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Az ezen a csatolási ponton lévő adatok elvesznének, kérjük csatolja be a könyvtárat egy másik helyre</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Folytatás</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>A csatolás sikertelen: A kiválasztott csatolási pont nem üres. Kérjük válasszon másikat!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1817,7 +1822,7 @@ kérjük legyen óvatos</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Kattintson a %1-re új partíció hozzáadásához. Kattintson a partícióra annak nevének és fájlrendszerének módosításához.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1837,7 +1842,7 @@ kérjük legyen óvatos</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Lemez:  </translation>
     </message>
@@ -1845,7 +1850,7 @@ kérjük legyen óvatos</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Fájlrendszer:  </translation>
     </message>
@@ -1911,8 +1916,8 @@ kérjük legyen óvatos</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>A hossz meghaladja a korlátot</translation>
     </message>
@@ -1927,33 +1932,33 @@ kérjük legyen óvatos</translation>
         <translation>Használja az sm4-xts-plain state kriptográfiai algoritmust a lemez titkosításához. Ha titkosítva van, akkor vissza kell fejtenie azt a felcsatolás előtt. Azok az operációs rendszerek, amelyek nem támogatják az állapotkriptográfiai algoritmust, nem tudják visszafejteni a lemezt.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Az új partíciók száma meghaladja a korlátot</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Egy partíció titkosításához, annak méretének 100 MB-nál nagyobbnak kell lennie</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Állítson be jelszót az új partíció titkosításához</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>A jelszó elvesztésének elkerülése érdekében kérjük készítsen biztonsági másolatot jelszaváról, és őrizze meg azt megfelelően!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>A partíció létrehozásához legalább 52 MB-ra van szükség</translation>
     </message>

--- a/application/translations/deepin-diskmanager_nl.ts
+++ b/application/translations/deepin-diskmanager_nl.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>LV-naam:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>Vg-naam:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>LV-bestandssysteem:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Terugdraaien</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>LV-informatie:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>LV aanmaken:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Laatste logische volume wissen</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>LV-capaciteit:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Niet-toegewezen</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Gebruik het aes-xts-plain64-algoritme om de schijf te versleutelen. Ontsleutel de schijf alvorens hem aan te koppelen.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Gebruik het m4-xts-plain-vercijferingsalgoritme om de schijf te versleutelen. Ontsleutel de schijf alvorens hem aan te koppelen. Let op: de schijf kan niet worden ontsleuteld op besturingssystemen die dit algoritme niet ondersteunen.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Volumes dienen groter dan 100 MiB te zijn om versleuteld te kunnen worden</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Tip: noteer je wachtwoord ergens en bewaar het op een veilige plaats.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -1689,54 +1689,59 @@ alle gegevens verloren!</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>%1 aankoppelen</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Kies een aankoppelpunt</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Aankoppelpunt:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Aankoppelen</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>Het aankoppelen is mislukt omdat het gekozen aankoppelpunt niet leeg is. Kies een ander punt!</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>Oké</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>De gegevens van dit aankoppelpunt worden permanent verwijderd. Koppel de map aan op een andere locatie.</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Doorgaan</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Het aankoppelen is mislukt omdat het gekozen aankoppelpunt niet leeg is. Kies een ander punt!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Oké</translation>
     </message>
 </context>
 <context>
@@ -1817,7 +1822,7 @@ alle gegevens verloren!</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Klik op ‘%1’ om het aantal partities uit te breiden. Klik op een partitie om de naam en het bestandssysteem aan te passen.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1837,7 +1842,7 @@ alle gegevens verloren!</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Schijf:</translation>
     </message>
@@ -1845,7 +1850,7 @@ alle gegevens verloren!</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Bestandssysteem:</translation>
     </message>
@@ -1911,8 +1916,8 @@ alle gegevens verloren!</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>De lengte overschrijdt het limiet</translation>
     </message>
@@ -1927,33 +1932,33 @@ alle gegevens verloren!</translation>
         <translation>Gebruik het m4-xts-plain-vercijferingsalgoritme om de schijf te versleutelen. Ontsleutel de schijf alvorens hem aan te koppelen. Let op: de schijf kan niet worden ontsleuteld op besturingssystemen die dit algoritme niet ondersteunen.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Het aantal nieuwe partities overschrijdt het limiet</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Volumes dienen groter dan 100 MiB te zijn om versleuteld te kunnen worden</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Stel een wachtwoord in om de nieuwe partitie te versleutelen</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Tip: noteer je wachtwoord ergens en bewaar het op een veilige plaats.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Je hebt minimaal 52 MB vrije ruimte nodig om een partitie te maken</translation>
     </message>

--- a/application/translations/deepin-diskmanager_pl.ts
+++ b/application/translations/deepin-diskmanager_pl.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>Nazwa WL:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>Nazwa GW:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>System plików WL:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Przywróć</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>Informacje WL</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>Utwórz WL:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Usuń ostatni wolumin logiczny</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>Pojemność WL:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Nieprzydzielone</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Użyj standardowego algorytmu aes-xts-plain64, aby zaszyfrować dysk. Pamiętaj o rozszyfrowaniu przed montowaniem go ponownie.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Użyj kryptograficznego algorytmu sm4-xts-plain, aby zaszyfrować dysk. Pamiętaj o rozszyfrowaniu przed montowaniem go ponownie. Systemy operacyjne, które nie wspierają kryptograficznych algorytmów, nie będą w stanie rozszyfrować dysku.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Wymagane jest 100 MiB, aby zaszyfrować wolumin</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Aby uniknąć utraty hasła, prosimy o zapisanie go w bezpiecznym miejscu!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -582,12 +582,12 @@ sformatuje ją i usunie jej hasło.</translation>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="354"/>
         <source>Wrong password, %1 chances left</source>
-        <translation>Nieprawidłowe hasło, pozostały %1 próby</translation>
+        <translation>Błędne hasło, pozostały %1 próby</translation>
     </message>
     <message>
         <location filename="../widgets/decryptdialog.cpp" line="356"/>
         <source>Wrong password, only one chance left</source>
-        <translation>Nieprawidłowe hasło, pozostała tylko jedna próba</translation>
+        <translation>Błędne hasło, pozostała tylko jedna próba</translation>
     </message>
 </context>
 <context>
@@ -1233,7 +1233,7 @@ sformatuje ją i usunie jej hasło.</translation>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="403"/>
         <source>Wrong path</source>
-        <translation>Nieprawidłowa ścieżka</translation>
+        <translation>Błędna ścieżka</translation>
     </message>
     <message>
         <location filename="../widgets/diskhealthdetectiondialog.cpp" line="411"/>
@@ -1360,7 +1360,7 @@ sformatuje ją i usunie jej hasło.</translation>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="166"/>
         <source>Wrong path</source>
-        <translation>Nieprawidłowa ścieżka</translation>
+        <translation>Błędna ścieżka</translation>
     </message>
     <message>
         <location filename="../widgets/diskinfodisplaydialog.cpp" line="174"/>
@@ -1687,54 +1687,59 @@ sformatuje ją i usunie jej hasło.</translation>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>Zamontuj %1</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Wybierz punkt montowania</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Punkt montowania:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Zamontuj</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>Błąd montowania: Wybrany punkt montowania nie jest pusty. Spróbuj wybrać inny.</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Dane w tym punkcie montowania zostaną utracone, zamontuj katalog w innej lokalizacji</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Kontynuuj</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Błąd montowania: Wybrany punkt montowania nie jest pusty. Spróbuj wybrać inny.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1815,7 +1820,7 @@ sformatuje ją i usunie jej hasło.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Kliknij %1, aby zwiększyć liczbę partycji. Kliknij każdą partycję, aby zmienić jej nazwę i system plików.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1835,7 +1840,7 @@ sformatuje ją i usunie jej hasło.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Dysk:</translation>
     </message>
@@ -1843,7 +1848,7 @@ sformatuje ją i usunie jej hasło.</translation>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>System plików:</translation>
     </message>
@@ -1909,8 +1914,8 @@ sformatuje ją i usunie jej hasło.</translation>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>Długość przekracza limit</translation>
     </message>
@@ -1925,33 +1930,33 @@ sformatuje ją i usunie jej hasło.</translation>
         <translation>Użyj kryptograficznego algorytmu sm4-xts-plain, aby zaszyfrować dysk. Pamiętaj o rozszyfrowaniu przed montowaniem go ponownie. Systemy operacyjne, które nie wspierają kryptograficznych algorytmów, nie będą w stanie rozszyfrować dysku.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Liczba nowych partycji przekracza limit</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Wymagane jest 100 MiB, aby zaszyfrować partycję</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Ustaw hasło do zaszyfrowania nowej partycji</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Aby uniknąć utraty hasła, prosimy o zapisanie go w bezpiecznym miejscu!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Aby utworzyć partycję, potrzebujesz co najmniej 52MB</translation>
     </message>

--- a/application/translations/deepin-diskmanager_sq.ts
+++ b/application/translations/deepin-diskmanager_sq.ts
@@ -9,7 +9,7 @@
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="57"/>
         <source>Click %1 to create a logical volume. </source>
-        <translation type="unfinished"/>
+        <translation>Klikoni mbi %1 që të krijoni një vëllim logjik. </translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="124"/>
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>Emër VL:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>Emër GV:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>Sistem kartelash VL:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Riktheje</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>Hollësi VL</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>Krijo VL:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Fshi vëllimin e fundit logjik</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>Kapacitet VL:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Të padhëna</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Përdor algoritmin standard aes-xts-plain64 për të fshehtëzuar diskun. Duhet ta shfshehtëzoni, para se ta montoni sërish.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Përdor algoritmin kriptogrfik sm4-xts-plain state për të fshehtëzuar diskun. Duhet ta shfshehtëzoni, para se ta montoni sërish. Sistemet Operativë që nuk mbulojnë algoritme kriptografike gjendjeje s’do të jenë në gjendje të shfshehtëzojnë diskun.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Që të fshehtëzoni një vëllim, duhet të jetë më i madh se 100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Që të shmangni humbjen e fjalëkalimit, ju lutemi, bëjini fjalëkalimit një kopjeruajtje dhe ruajeni si duhet!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1689,54 +1689,59 @@ do të humbasin, nëse krijohet një tabelë e re pjesësh,
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>Monto %1</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Ju lutemi, zgjidhni një pikë montimi</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Pikë montimi:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Montoni</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Të dhënat nën këtë pikë montimi do të humbnin, ju lutemi, montojeni drejtorinë te një vendndodhje tjetër</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Vazhdo</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Montimi dështoi: Pika e përzgjedhur e montimit s’është e zbrazët. Ju lutemi, përzgjidhni një tjetër!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
@@ -1817,7 +1822,7 @@ do të humbasin, nëse krijohet një tabelë e re pjesësh,
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Klikoni mbi %1 që të shtoni numrin e pjesëve. Klikoni mbi secilën pjesë që të ndryshoni emrin e saj dhe sistemin e kartelave për të.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1837,7 +1842,7 @@ do të humbasin, nëse krijohet një tabelë e re pjesësh,
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Disk:</translation>
     </message>
@@ -1845,7 +1850,7 @@ do të humbasin, nëse krijohet një tabelë e re pjesësh,
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Sistem kartelash:</translation>
     </message>
@@ -1911,8 +1916,8 @@ do të humbasin, nëse krijohet një tabelë e re pjesësh,
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>Gjatësia tejkalon kufirin</translation>
     </message>
@@ -1927,33 +1932,33 @@ do të humbasin, nëse krijohet një tabelë e re pjesësh,
         <translation>Përdor algoritmin kriptografik shtetëror sm4-xts-plain për të fshehtëzuar diskun. Nëse është i fshehtëzuar, duhet ta shfshehtëzoni, para se ta montoni. Sistemet Operativë që nuk mbulojnë algoritme kriptografike shtetërore, s’do të jenë në gjendje të shfshehtëzojnë diskun.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Numri i pjesëve të reja tejkalon kufirin</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Që të fshehtëzoni një vëllim, duhet të jetë më i madh se 100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Caktoni një fjalëkalim për fshehtëzimin e pjesës së re</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Që të shmangni humbjen e fjalëkalimit, ju lutemi, bëjini fjalëkalimit një kopjeruajtje dhe ruajeni si duhet!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Për të krijuar një pjesë, ju duhet të paktën 52 MB</translation>
     </message>

--- a/application/translations/deepin-diskmanager_uk.ts
+++ b/application/translations/deepin-diskmanager_uk.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>Назва ЛТ:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>Назва ГТ:</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>Файлова система ЛТ:</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>Повернути</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>Відомості щодо ЛТ</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>Створити ЛТ:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>Вилучити останній логічний том</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>Місткість ЛТ:</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>Нерозподілено</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>Скористатися для шифрування диска стандартним алгоритмом aes-xts-plain64. Вам доведеться розшифрувати його, перш ніж монтувати знову.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>Скористатися для шифрування диска державним криптографічним алгоритмом sm4-xts-plain. Вам доведеться розшифрувати його, перш ніж монтувати знову. В операційних системах, де не передбачено підтримки державного криптографічного алгоритму, розшифрування диска буде неможливим.</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>Для шифрування тому його розміри мають перевищувати 100 МіБ</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Щоб не втратити доступ, будь ласка, створіть резервну копію вашого пароля і зберігайте її належним чином!</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
@@ -1689,54 +1689,59 @@ will format it and remove its password.</source>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>Змонтувати %1</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>Виберіть, будь ласка, точку монтування</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>Точка монтування:</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>Змонтувати</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>Не вдалося змонтувати: вибрана точка монтування не є порожньою. Будь ласка, виберіть якусь іншу!</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>Гаразд</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>Дані з цією точкою монтування може бути втрачено. Будь ласка, змонтуйте каталог до іншої теки.</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>Продовжити</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>Не вдалося змонтувати: вибрана точка монтування не є порожньою. Будь ласка, виберіть якусь іншу!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Гаразд</translation>
     </message>
 </context>
 <context>
@@ -1817,7 +1822,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="61"/>
         <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
-        <translation type="unfinished"/>
+        <translation>Натисніть «%1», щоб збільшити кількість розділів. Клацніть на будь-якому розділі, щоб змінити його назву і файлову систему.</translation>
     </message>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="128"/>
@@ -1837,7 +1842,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>Диск:</translation>
     </message>
@@ -1845,7 +1850,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>Файлова система:</translation>
     </message>
@@ -1911,8 +1916,8 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>Перевищено обмеження на довжину</translation>
     </message>
@@ -1927,33 +1932,33 @@ will format it and remove its password.</source>
         <translation>Скористатися для шифрування диска державним криптографічним алгоритмом sm4-xts-plain. Якщо його зашифровано, вам доведеться розшифрувати його, перш ніж монтувати. В операційних системах, де не передбачено підтримки державного криптографічного алгоритму, розшифрування диска буде неможливим.</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>Кількість нових розділів перевищує максимальну можливу</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>Для шифрування розділу його розміри мають перевищувати 100 МіБ</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>Встановіть пароль для шифрування нового розділу</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>Щоб не втратити доступ, будь ласка, створіть резервну копію вашого пароля і зберігайте її належним чином!</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>Щоб створити розділ, вам потрібно принаймні 52 МБ</translation>
     </message>

--- a/application/translations/deepin-diskmanager_zh_CN.ts
+++ b/application/translations/deepin-diskmanager_zh_CN.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>逻辑卷名称：</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>卷组名称：</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>逻辑卷格式：</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>复 原</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>逻辑卷信息</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>创建逻辑卷：</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>删除最新逻辑卷</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>逻辑卷大小：</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>未分配</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>分区名称</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>分区大小</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>使用aes-xts-plain64标准算法加密，卸载后需要解锁才能挂载。</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>使用sm4-xts-plain国密算法加密，卸载后需要解锁才能挂载。不支持国密算法的系统将无法解锁。</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>加密卷空间需要大于100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>为防止遗忘密码，请您自行备份密码，并妥善保存！</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -1688,54 +1688,64 @@ will format it and remove its password.</source>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>将对%1进行挂载</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>请先设置挂载点</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>挂载点：</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="92"/>
+        <source>Please select /mnt or /media, or its subdirectories.</source>
+        <translation>请选择/mnt或者/media以及其子目录。</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation>该挂载点非法。请选择/mnt或者/media以及其子目录。</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>挂载</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>所选挂载点不为空，挂载失败，请更换挂载点！</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>确 定</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>此挂载点的数据可能会丢失，建议将目录挂载到其他位置</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>继 续</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>所选挂载点不为空，挂载失败，请更换挂载点！</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>确 定</translation>
     </message>
 </context>
 <context>
@@ -1836,7 +1846,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>磁盘：</translation>
     </message>
@@ -1844,7 +1854,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>分区格式：</translation>
     </message>
@@ -1910,8 +1920,8 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>字符长度超过范围</translation>
     </message>
@@ -1926,33 +1936,33 @@ will format it and remove its password.</source>
         <translation>使用sm4-xts-plain国密算法加密，加密后需要解锁才能挂载。不支持国密算法的系统将无法解锁。</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>新分区数超出限制</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>加密分区空间需要大于100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>将对新建分区进行加密</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>为防止遗忘密码，请您自行备份密码，并妥善保存！</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>分区空间不得小于52 MB，否则无法创建</translation>
     </message>

--- a/application/translations/deepin-diskmanager_zh_HK.ts
+++ b/application/translations/deepin-diskmanager_zh_HK.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>邏輯卷名稱：</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>卷組名稱：</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>邏輯卷格式：</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>復 原</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>邏輯卷訊息</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>創建邏輯卷：</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>刪除最新邏輯卷</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>邏輯卷大小：</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>未分配</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>分區名稱</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>分區大小</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>使用aes-xts-plain64標準算法加密，卸載後需要解鎖才能掛載。</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>使用sm4-xts-plain國密算法加密，卸載後需要解鎖才能掛載。不支持國密算法的系統將無法解鎖。</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>加密卷空間需要大於100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>為防止遺忘密碼，請您自行備份密碼，並妥善保存！</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -1688,54 +1688,64 @@ will format it and remove its password.</source>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>將對%1進行掛載</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>請先設置掛載點</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>掛載點：</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="92"/>
+        <source>Please select /mnt or /media, or its subdirectories.</source>
+        <translation>請選擇/mnt或者/media以及其子目錄。</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation>該掛載點非法。請選擇/mnt或者/media以及其子目錄。</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>掛載</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>所選掛載點不為空，掛載失敗，請更換掛載點！</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>此掛載點的數據可能會丟失，建議將目錄掛載到其他位置</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼 續</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>所選掛載點不為空，掛載失敗，請更換掛載點！</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>確 定</translation>
     </message>
 </context>
 <context>
@@ -1836,7 +1846,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>磁盤：</translation>
     </message>
@@ -1844,7 +1854,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>分區格式：</translation>
     </message>
@@ -1910,8 +1920,8 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>字符長度超過範圍</translation>
     </message>
@@ -1926,33 +1936,33 @@ will format it and remove its password.</source>
         <translation>使用sm4-xts-plain國密算法加密，加密後需要解鎖才能掛載。不支持國密算法的系統將無法解鎖。</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>新分區數超出限制</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>加密分區空間需要大於100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>將對新建分區進行加密</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>為防止遺忘密碼，請您自行備份密碼，並妥善保存！</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>分區空間不得小於52 MB，否則無法創建</translation>
     </message>

--- a/application/translations/deepin-diskmanager_zh_TW.ts
+++ b/application/translations/deepin-diskmanager_zh_TW.ts
@@ -23,22 +23,22 @@
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="148"/>
-        <location filename="../widgets/createlvwidget.cpp" line="312"/>
+        <location filename="../widgets/createlvwidget.cpp" line="313"/>
         <source>LV name:</source>
         <translation>邏輯卷名稱：</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="157"/>
         <location filename="../widgets/createlvwidget.cpp" line="161"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1004"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
         <source>VG name:</source>
         <translation>卷組名稱：</translation>
     </message>
     <message>
         <location filename="../widgets/createlvwidget.cpp" line="169"/>
-        <location filename="../widgets/createlvwidget.cpp" line="333"/>
-        <location filename="../widgets/createlvwidget.cpp" line="377"/>
-        <location filename="../widgets/createlvwidget.cpp" line="1005"/>
+        <location filename="../widgets/createlvwidget.cpp" line="334"/>
+        <location filename="../widgets/createlvwidget.cpp" line="378"/>
+        <location filename="../widgets/createlvwidget.cpp" line="1006"/>
         <source>LV file system:</source>
         <translation>邏輯卷格式：</translation>
     </message>
@@ -61,63 +61,63 @@
         <translation>復 原</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="279"/>
+        <location filename="../widgets/createlvwidget.cpp" line="280"/>
         <source>LV Information</source>
         <translation>邏輯卷訊息</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="291"/>
+        <location filename="../widgets/createlvwidget.cpp" line="292"/>
         <source>Create LV:</source>
         <translation>建立邏輯卷：</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="302"/>
+        <location filename="../widgets/createlvwidget.cpp" line="303"/>
         <source>Delete last logical volume</source>
         <translation>刪除最新邏輯卷</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="342"/>
+        <location filename="../widgets/createlvwidget.cpp" line="343"/>
         <source>LV capacity:</source>
         <translation>邏輯卷大小：</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="524"/>
-        <location filename="../widgets/createlvwidget.cpp" line="614"/>
+        <location filename="../widgets/createlvwidget.cpp" line="525"/>
+        <location filename="../widgets/createlvwidget.cpp" line="615"/>
         <source>Unallocated</source>
         <translation>未分配</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="547"/>
+        <location filename="../widgets/createlvwidget.cpp" line="548"/>
         <source>Name</source>
         <translation>分區名稱</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="548"/>
+        <location filename="../widgets/createlvwidget.cpp" line="549"/>
         <source>Size</source>
         <translation>分區大小</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="717"/>
+        <location filename="../widgets/createlvwidget.cpp" line="718"/>
         <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
         <translation>使用aes-xts-plain64標準演算法加密，移除後需要解鎖才能掛載。</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="723"/>
+        <location filename="../widgets/createlvwidget.cpp" line="724"/>
         <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
         <translation>使用sm4-xts-plain國密演算法加密，移除後需要解鎖才能掛載。不支援國密演算法的系統將無法解鎖。</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="817"/>
+        <location filename="../widgets/createlvwidget.cpp" line="818"/>
         <source>To encrypt a volume, it should be larger than 100 MiB</source>
         <translation>加密卷空間需要大於100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="845"/>
+        <location filename="../widgets/createlvwidget.cpp" line="846"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>為防止遺忘密碼，請您自行備份密碼，並妥善儲存！</translation>
     </message>
     <message>
-        <location filename="../widgets/createlvwidget.cpp" line="846"/>
+        <location filename="../widgets/createlvwidget.cpp" line="847"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -1688,54 +1688,64 @@ will format it and remove its password.</source>
 <context>
     <name>MountDialog</name>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="49"/>
-        <location filename="../widgets/mountdialog.cpp" line="52"/>
-        <location filename="../widgets/mountdialog.cpp" line="55"/>
+        <location filename="../widgets/mountdialog.cpp" line="50"/>
+        <location filename="../widgets/mountdialog.cpp" line="53"/>
+        <location filename="../widgets/mountdialog.cpp" line="56"/>
         <source>Mount %1</source>
         <translation>將對%1進行掛載</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="59"/>
+        <location filename="../widgets/mountdialog.cpp" line="60"/>
         <source>Choose a mount point please</source>
         <translation>請先設定掛載點</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="62"/>
+        <location filename="../widgets/mountdialog.cpp" line="63"/>
         <source>Mount point:</source>
         <translation>掛載點：</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="90"/>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="92"/>
+        <source>Please select /mnt or /media, or its subdirectories.</source>
+        <translation>請選擇/mnt或者/media以及其子目錄。</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="99"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation>該掛載點非法。請選擇/mnt或者/media以及其子目錄。</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="109"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <location filename="../widgets/mountdialog.cpp" line="110"/>
         <source>Mount</source>
         <translation>掛載</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="283"/>
-        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
-        <translation>所選掛載點不為空，掛載失敗，請更換掛載點！</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="284"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <location filename="../widgets/mountdialog.cpp" line="276"/>
         <source>The data under this mount point would be lost, please mount the directory to another location</source>
         <translation>此掛載點的資料可能會遺失，建議將目錄掛載到其他位置</translation>
     </message>
     <message>
-        <location filename="../widgets/mountdialog.cpp" line="260"/>
+        <location filename="../widgets/mountdialog.cpp" line="277"/>
         <source>Continue</source>
         <comment>button</comment>
         <translation>繼 續</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="300"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>所選掛載點不為空，掛載失敗，請更換掛載點！</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="301"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>確 定</translation>
     </message>
 </context>
 <context>
@@ -1836,7 +1846,7 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="161"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="165"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1107"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
         <source>Disk:</source>
         <translation>磁碟：</translation>
     </message>
@@ -1844,7 +1854,7 @@ will format it and remove its password.</source>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="173"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="335"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="379"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1108"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="1109"/>
         <source>File system:</source>
         <translation>分區格式：</translation>
     </message>
@@ -1910,8 +1920,8 @@ will format it and remove its password.</source>
     <message>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="702"/>
         <location filename="../widgets/customcontrol/partitionwidget.cpp" line="712"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="814"/>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="824"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="815"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="825"/>
         <source>The length exceeds the limit</source>
         <translation>字元長度超過範圍</translation>
     </message>
@@ -1926,33 +1936,33 @@ will format it and remove its password.</source>
         <translation>使用sm4-xts-plain國密演算法加密，加密後需要解鎖才能掛載。不支援國密演算法的系統將無法解鎖。</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="856"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="857"/>
         <source>The number of new partitions exceeds the limit</source>
         <translation>新分區數超出限制</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="879"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="880"/>
         <source>To encrypt a partition, it should be larger than 100 MiB</source>
         <translation>加密分區空間需要大於100 MiB</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="887"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="888"/>
         <source>Set a password to encrypt the new partition</source>
         <translation>將對建立分區進行加密</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="906"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
         <source>To avoid losing the password, please back up your password and keep it properly!</source>
         <translation>為防止遺忘密碼，請您自行備份密碼，並妥善儲存！</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="907"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="908"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="920"/>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="921"/>
         <source>To create a partition, you need at least 52 MB</source>
         <translation>分區空間不得小於52 MB，否則無法建立</translation>
     </message>

--- a/application/widgets/mountdialog.h
+++ b/application/widgets/mountdialog.h
@@ -30,6 +30,7 @@
 
 #include <dfilechooseredit.h>
 #include <DComboBox>
+#include <DLabel>
 #include <commondef.h>
 
 DWIDGET_USE_NAMESPACE
@@ -96,6 +97,7 @@ private slots:
 
 private:
     DFileChooserEdit *m_fileChooserEdit;
+    DLabel *m_warnning;
 //    DComboBox *m_ComboBox;
 };
 


### PR DESCRIPTION
Description: 系统运行相关目录挂载的时候，目录文件被新设备里的内容替换。原有文件失效

Log: 只允许挂载/mnt和/media及其子目录。选择的挂载目录非上述目录则提示非法挂载点，且不能点击挂载按钮

Bug: https://pms.uniontech.com/bug-view-153001.html