### PR TITLE
fix: 新建ntfs格式的lvm分区，没有自动挂载，擦除后也不自动挂载

### DIFF
--- a/service/diskoperation/filesystems/ntfs.cpp
+++ b/service/diskoperation/filesystems/ntfs.cpp
@@ -182,7 +182,7 @@ bool NTFS::resize(const QString &path, const QString &sizeByte, bool fillPartiti
         size = QString(" -s %1k").arg(sizeByte);
     }
 
-    Utils::executCmd(QString("umount %1").arg(path));
+    //Utils::executCmd(QString("umount %1").arg(path));
 
     cmd = "ntfsresize --force --force" + size ;
     // Real resize
@@ -222,7 +222,7 @@ FS_Limits NTFS::getFilesystemLimits(const QString &path)
 {
     m_fsLimits = FS_Limits {-1, -1};
     QString cmd, output, error;
-    Utils::executCmd(QString("umount %1").arg(path), output, error);
+    //Utils::executCmd(QString("umount %1").arg(path), output, error);
     cmd = QString("ntfsresize -m -f %1").arg(path);
     if (Utils::executCmd(cmd, output, error) != 0 && error.compare("Unknown error") != 0) {
         return m_fsLimits;

--- a/service/diskoperation/partedcore.cpp
+++ b/service/diskoperation/partedcore.cpp
@@ -2088,10 +2088,10 @@ void PartedCore::syncDeviceInfo(/*const QMap<QString, Device> deviceMap, */const
 {
     qDebug() << "syncDeviceInfo finally!";
 
-    foreach (auto dev, m_mountPointExclude) {
-        QString output, error;
-        Utils::executCmd(QString("umount -v %1").arg(dev), output, error);
-    }
+//    foreach (auto dev, m_mountPointExclude) {
+//        QString output, error;
+//        Utils::executCmd(QString("umount -v %1").arg(dev), output, error);
+//    }
 
     //m_deviceMap = deviceMap;
     m_deviceMap = m_probeThread.getDeviceMap();


### PR DESCRIPTION
Description: getFileSystemLimits和resize方法中将ntfs格式umount了，umount的原因是解决分区被自动挂载导致功能命令执行失败的问题。
             当前已恢复使用/usr/lib/udisks2/udisks2-inhibit拉起deepin-diskmanager-service，分区不会被自动挂载了。故删除umount

Log:

Bug: https://pms.uniontech.com/bug-view-154323.html