### PR TITLE
fix: 输入比剩余空间大的值，点击“+”号按钮，页面显示异常

### DIFF
--- a/application/widgets/createlvwidget.cpp
+++ b/application/widgets/createlvwidget.cpp
@@ -787,7 +787,7 @@ void CreateLVWidget::onSetSliderValue()
     m_slider->setValue(static_cast<int>((value / (m_total - (sumValue() / 1024))) * 100));
     m_currentEditSize = QString::number(value * 1024, 'f', 2);
 
-    if (0.00 == value) {
+    if (0.00 == value || value > (m_total - sumValue() / 1024)) {
         m_addButton->setDisabled(true);
     } else {
         m_addButton->setDisabled(false);

--- a/application/widgets/customcontrol/partitionwidget.cpp
+++ b/application/widgets/customcontrol/partitionwidget.cpp
@@ -777,6 +777,7 @@ void PartitionWidget::onSliderValueChanged(int value)
     m_currentEditSize = QString::number((static_cast<double>(value) / 100) * (m_totalSize - sumValue()), 'f', 4);
     qDebug() << m_currentEditSize << size << value << m_totalSize - sumValue();
     m_block = 0;
+    //m_addButton->setEnabled(m_currentEditSize <= )
 }
 
 void PartitionWidget::onSetSliderValue()
@@ -797,6 +798,11 @@ void PartitionWidget::onSetSliderValue()
     m_block = 1;
     m_slider->setValue(static_cast<int>((value / (m_total - (sumValue() / 1024))) * 100));
     m_currentEditSize = QString::number(value * 1024, 'f', 4);
+    if (value == 0.00 || value > (m_total - sumValue() / 1024)) {
+        m_addButton->setEnabled(false);
+    } else {
+        m_addButton->setEnabled(true);
+    }
     //    qDebug() << currentEditSize;
     //    qDebug() << value * 1024 << static_cast<int>((value / total) * 100);
 }


### PR DESCRIPTION
Description: 手动输入的分区大小不合法，分区合法大小的判断标准是>0 且<=剩余空间

Log: 创建lv和分区都增加的大小校验，如果大小设置不合法则不能点击“+”