### PR TITLE
fix: avoid hardcode binary path

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -121,10 +121,13 @@ int main(int argc, char *argv[])
         cmd = QString("pidof deepin-diskmanager-service");
 
         if (!executCmd(cmd, outPut, error)) {
-            proc.startDetached("/usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.Quit");
+            proc.startDetached("dbus-send", {
+                "--system", "--type=method_call", "--dest=com.deepin.diskmanager",
+                "/com/deepin/diskmanager", "com.deepin.diskmanager.Quit"
+            });
         }
 
-        proc.startDetached("/usr/bin/deepin-diskmanager-authenticateProxy");
+        proc.startDetached("deepin-diskmanager-authenticateProxy", {});
 
         //正常启动程序后,循环查询后台服务是否已经启动,如果后台服务启动说明鉴权成功,启动前端界面
         while (1) {

--- a/application/widgets/mainwindow.cpp
+++ b/application/widgets/mainwindow.cpp
@@ -99,7 +99,10 @@ void MainWindow::closeEvent(QCloseEvent *event)
     m_central->HandleQuit();
 //    m_handler->Quit();
     QProcess proc;
-    proc.startDetached("/usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.Quit");
+    proc.startDetached("dbus-send", {
+        "--system", "--type=method_call", "--dest=com.deepin.diskmanager",
+        "/com/deepin/diskmanager", "com.deepin.diskmanager.Quit"
+    });
 
     DMainWindow::closeEvent(event);
 }
@@ -151,8 +154,10 @@ void MainWindow::onHandleQuitAction()
     qDebug() << __FUNCTION__;
 
     QProcess proc;
-    proc.startDetached("/usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.Quit");
-
+    proc.startDetached("dbus-send", {
+        "--system", "--type=method_call", "--dest=com.deepin.diskmanager",
+        "/com/deepin/diskmanager", "com.deepin.diskmanager.Quit"
+    });
 }
 
 QString MainWindow::getRootLoginResult()


### PR DESCRIPTION
避免硬编码可执行文件的路径，提高可移植性

`QProcess` 会自动在系统所设的 `PATH` 中查找可执行程序，而 `/usr/bin/` 通常会位于 `PATH` 中，不应当硬编码路径。

另外，单参数版本的 `QProcess::startDetached()` 已被 Qt 标记为废弃，此处也转而使用了分别提供可执行名称与参数列表的多参数版本。

- 是解决 https://github.com/linuxdeepin/developer-center/issues/3374 问题的一部分。