### PR TITLE
fix: 对KelvinV UOS的SDD6进行卸载，在系统提示之后仍执行卸载，在执行卸载之后提示卸载失败，之后功能正常，但是重启之后发现…

### DIFF
--- a/service/diskoperation/partedcore.cpp
+++ b/service/diskoperation/partedcore.cpp
@@ -1055,7 +1055,7 @@ bool PartedCore::unmount()
         return sendRefSigAndReturn(false, DISK_SIGNAL_TYPE_UMNT, true, "0");
     }
     QString type = Utils::fileSystemTypeToString(m_curpartition.m_fstype);//修改/etc/fstab
-    writeFstab(m_curpartition.m_uuid,  "", type, false);//非挂载 不需要挂载点
+    //writeFstab(m_curpartition.m_uuid,  "", type, false);//非挂载 不需要挂载点
     qDebug() << __FUNCTION__ << "Unmount end";
     addMountPointExclude(m_curpartition.getPath());
     return sendRefSigAndReturn(true, DISK_SIGNAL_TYPE_UMNT, true, "1");


### PR DESCRIPTION
…不能进入系统了

Description: 卸载分区时修改了/etc/fstab,删除掉了系统分区的开机自动挂载。导致无法进入系统

Log: 卸载分区不修改/etc/fstab

Bug: https://pms.uniontech.com/bug-view-130381.html 