### PR TITLE
fix: 解决卸载U盘分区后，提示卸载成功依然显示已挂载

### DIFF
--- a/application/partedproxy/dmdbushandler.cpp
+++ b/application/partedproxy/dmdbushandler.cpp
@@ -211,8 +211,23 @@ void DMDbusHandler::getDeviceInfo()
     qDebug() << __FUNCTION__ << "-------";
 }
 
-const DeviceInfoMap &DMDbusHandler::probDeviceInfo() const
+DeviceInfoMap &DMDbusHandler::probDeviceInfo()
 {
+    QFile file("/etc/mtab");
+    QString mounts;
+    if (file.open(QIODevice::ReadOnly)) {
+        mounts = file.readAll();
+        file.close();
+    }
+    if (!mounts.isEmpty()) {
+        for (auto &disk : m_deviceMap) {
+            for (auto &partition : disk.m_partition) {
+                if (!mounts.contains(partition.m_name)) {
+                    partition.m_mountPoints.clear();
+                }
+            }
+        }
+    }
     return m_deviceMap;
 }
 

--- a/application/partedproxy/dmdbushandler.h
+++ b/application/partedproxy/dmdbushandler.h
@@ -60,7 +60,7 @@ public:
     /**
      * @brief 获取所有设备信息
      */
-    const DeviceInfoMap &probDeviceInfo() const;
+    DeviceInfoMap &probDeviceInfo();
 
     /**
      * @brief 根据设备路径获取该设备的所有分区信息


### PR DESCRIPTION
Description: 设备挂载信息未更新

Log: 获取设备后，查询/etc/mtab。 如果设备没有挂载，则将挂载点清空

Bug: https://pms.uniontech.com/bug-view-170853.html