### PR TITLE
fix: 设备管理器中存储设备接口显示为UFS3.1，磁盘管理器中显示为UFS3.0，需保持一致

### DIFF
--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -537,7 +537,7 @@ void DeviceStorage::getDiskInfoInterface(const QString &devicePath, QString &int
 
     if (file.open(QIODevice::ReadOnly)) {
         if (model == file.readLine().simplified()) {
-            interface = "UFS 3.0";
+            interface = "UFS 3.1";
         }
         file.close();
     }


### PR DESCRIPTION
Description: 华为设备UFS3.0修改为UFS3.1

Log: 华为设备UFS3.0修改为UFS3.1

Bug: https://pms.uniontech.com/bug-view-166277.html