### PR TITLE
fix: GPT分区表中卸载分区，卸载成功，但是页面仍然显示有挂载点

### DIFF
--- a/application/partedproxy/dmdbushandler.cpp
+++ b/application/partedproxy/dmdbushandler.cpp
@@ -222,7 +222,7 @@ DeviceInfoMap &DMDbusHandler::probDeviceInfo()
     if (!mounts.isEmpty()) {
         for (auto &disk : m_deviceMap) {
             for (auto &partition : disk.m_partition) {
-                if (!mounts.contains(partition.m_name)) {
+                if (!mounts.contains(QString("%1%2").arg(partition.m_devicePath).arg(partition.m_partitionNumber))) {
                     partition.m_mountPoints.clear();
                 }
             }


### PR DESCRIPTION
Description: GPT磁盘获取的分区信息中设备节点名称为空，通过该设备节点查找挂载点信息出错，导致挂载信息未清除

Log: 使用设备名和分区编号组装设备节点名