### PR TITLE
fix: KLVU设备磁盘序列号显示乱码

### DIFF
--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -273,6 +273,11 @@ bool DeviceStorage::getDiskInfoFromHwinfo(const QString &devicePath)
 
     setHwinfoInfo(mapInfo);
 
+    //部分华为设备读取到是Serial ID为乱码
+    QString cid = Utils::readContent("/proc/bootdevice/cid");
+    if (!cid.isEmpty()) {
+        m_serialNumber = cid;
+    }
     return true;
 }
 


### PR DESCRIPTION
Description: 通过hwinfo以及smart获取的值是乱码。

Log: 针对该类型设备通过/proc/deviceboot/cid获取序列号