### PR TITLE
fix: 本机硬盘的分区挂载点显示为空，没有将挂载点正常显示出来

### DIFF
--- a/application/partedproxy/dmdbushandler.cpp
+++ b/application/partedproxy/dmdbushandler.cpp
@@ -222,7 +222,15 @@ DeviceInfoMap &DMDbusHandler::probDeviceInfo()
     if (!mounts.isEmpty()) {
         for (auto &disk : m_deviceMap) {
             for (auto &partition : disk.m_partition) {
-                if (!mounts.contains(QString("%1%2").arg(partition.m_devicePath).arg(partition.m_partitionNumber))) {
+                QString partitionName = partition.m_name;
+                if (partitionName.isEmpty()) {
+                    if (partitionName.contains("nvme")) {
+                        partitionName = QString("%1p%2").arg(partition.m_devicePath).arg(partition.m_partitionNumber);
+                    } else {
+                        partitionName = QString("%1%2").arg(partition.m_devicePath).arg(partition.m_partitionNumber);
+                    }
+                }
+                if (!mounts.contains(partitionName)) {
                     partition.m_mountPoints.clear();
                 }
             }


### PR DESCRIPTION
Description: nvme磁盘的分区名称构造错误，导致识别挂载信息有误

Log: nvme设备特殊处理