### PR TITLE
fix: Fix front-end startup stuck

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -120,11 +120,11 @@ int main(int argc, char *argv[])
 //    }
     if (a.setSingleInstance(appName)) {
         QProcess proc;
-        QString cmd, outPut, error;
+        QString cmd, oldPid, newPid, error;
         //先判断后台服务进程是否存在,如果存在可能是强制退出导致,应先退出后台程序再重新启动磁盘管理器
         cmd = QString("pidof deepin-diskmanager-service");
 
-        if (!executCmd(cmd, outPut, error)) {
+        if (!executCmd(cmd, oldPid, error)) {
             proc.startDetached("/usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.Quit");
         }
 
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
         while (1) {
             cmd = QString("pidof deepin-diskmanager-service");
 
-            if (!executCmd(cmd, outPut, error)) {
+            if (!executCmd(cmd, newPid, error) && oldPid != newPid) {
                 break;
             }
             QThread::msleep(300);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-diskmanager (1.3.32) stable; urgency=medium
+
+  * fix front-end startup stuck
+
+ -- wangrong <wangrong@uniontech.com>  Fri, 19 Jan 2024 09:53:33 +0800
+
 deepin-diskmanager (1.3.31) stable; urgency=medium
 
   * fix: mount as root


### PR DESCRIPTION
When the disk manager starts, it will send an quit message to the background service, then start a new background service, and wait for the new background service to start before displaying the main interface.

In the extreme case, when the old service has not exited and the new service has not been started, the front end detects the existence of the service, then displays the main interface and sends a request to the old service. Since the old service may have exited during the execution of the request, the front end cannot receive the updateDeviceInfo signal and remains in the initialization interface.

The solution is that the front end needs to determine the PID of the service process when waiting for the new background service to start to ensure that the new service is running.

Log: fix front-end startup stuck
Bug: https://pms.uniontech.com/bug-view-239747.html