### PR TITLE
fix: Fix mount ntfs fail

### DIFF
--- a/service/diskmanagerservice.cpp
+++ b/service/diskmanagerservice.cpp
@@ -105,7 +105,8 @@ bool DiskManagerService::unmount()
 
 bool DiskManagerService::mount(const QString &mountpath)
 {
-    return m_partedcore->mountAndWriteFstab(mountpath);
+    QString invokerUid = QString::number(connection().interface()->serviceUid(message().service()).value());
+    return m_partedcore->mountAndWriteFstab(mountpath, invokerUid);
 }
 
 bool DiskManagerService::deCrypt(const LUKS_INFO &luks)

--- a/service/diskoperation/partedcore.cpp
+++ b/service/diskoperation/partedcore.cpp
@@ -1029,11 +1029,11 @@ void PartedCore::setCurSelect(const PartitionInfo &info)
     }
 }
 
-bool PartedCore::mountAndWriteFstab(const QString &mountpath)
+bool PartedCore::mountAndWriteFstab(const QString &mountpath, const QString &mountUid)
 {
     qDebug() << __FUNCTION__ << "Permanent mount start";
     QString type = Utils::fileSystemTypeToString(m_curpartition.m_fstype);
-    bool success = mountDevice(mountpath, m_curpartition.getPath(),  m_curpartition.m_fstype)  //位置不可交换 利用&&运算特性
+    bool success = mountDevice(mountpath, m_curpartition.getPath(),  m_curpartition.m_fstype, mountUid)  //位置不可交换 利用&&运算特性
                    && writeFstab(m_curpartition.m_uuid, mountpath, type, true);
     qDebug() << __FUNCTION__ << "Permanent mount end";
     deleteMountPointExclude(m_curpartition.getPath());

--- a/service/diskoperation/partedcore.h
+++ b/service/diskoperation/partedcore.h
@@ -172,9 +172,10 @@ public:
     /**
      * @brief 挂载分区
      * @param mountpath：挂载路径
+     * @param mountUid：挂载用户
      * @return true成功false失败
      */
-    bool mountAndWriteFstab(const QString &mountpath);
+    bool mountAndWriteFstab(const QString &mountpath, const QString &mountUid);
 
     /**
      * @brief 卸载分区


### PR DESCRIPTION
When mounting ntfs, the mount option uid/gid is used, but diskmanager uses an empty string when mounting, causing the mount to fail. The solution is to pass in the user ID.

Log: fix mount ntfs fail