### PR TITLE
fix: fix umount all USB devices at sometimes

### DIFF
--- a/service/udev/USBadd.sh
+++ b/service/udev/USBadd.sh
@@ -6,8 +6,8 @@
 
 PROC_NAME='deepin-diskmanager'
 
-#ProcNumber=`pidof $PROC_NAME`
-ProcNumber=`ps aux |grep deepin-diskmanager-service |sed '/grep/d' |sed '/tail/d'`
+# 前端进程'deepin-diskmanager'起来会设置udisks2-inhibit，只有磁盘管理器启动时才需DBus更新挂/卸载
+ProcNumber=`ps aux |grep udisks2-inhibit |sed '/grep/d' |sed '/tail/d'`
 if [ -n "$ProcNumber" ];then
    /usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.updateUsb
 else

--- a/service/udev/USBremove.sh
+++ b/service/udev/USBremove.sh
@@ -6,8 +6,8 @@
 
 PROC_NAME='deepin-diskmanager'
 
-#ProcNumber=`pidof $PROC_NAME`
-ProcNumber=`ps aux |grep deepin-diskmanager-service |sed '/grep/d' |sed '/tail/d'`
+# 前端进程'deepin-diskmanager'起来会设置udisks2-inhibit，只有磁盘管理器启动时才需DBus更新挂/卸载
+ProcNumber=`ps aux |grep udisks2-inhibit |sed '/grep/d' |sed '/tail/d'`
 if [ -n "$ProcNumber" ];then
    /usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.updateUsbRemove
 else


### PR DESCRIPTION
It needs to refresh USB devices info only for diskmanager, but the backend Dbus service may be actived.

Log: Fix USB devices are removed issue.
Bug: https://pms.uniontech.com/bug-view-244767.html