### PR TITLE
fix: Fix diskmanager-daemon.service auto-start

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-diskmanager (1.3.33) stable; urgency=medium
+
+  * update rules to disable service
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 05 Mar 2024 15:40:38 +0800
+
 deepin-diskmanager (1.3.32) stable; urgency=medium
 
   * fix front-end startup stuck

--- a/debian/deepin-diskmanager.postinst
+++ b/debian/deepin-diskmanager.postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+deb-systemd-helper disable 'diskmanager-daemon.service' >/dev/null || true

--- a/debian/rules
+++ b/debian/rules
@@ -15,5 +15,5 @@ override_dh_auto_configure:
 override_dh_auto_test:
 	# Disable auto tests at build time
 
-override_dh_systemd_enable:
-    # Disable diskmanager-daemon.service auto-start
+override_dh_installsystemd:
+	# Disable diskmanager-daemon.service auto-start


### PR DESCRIPTION
Disable the service by updating the rules file.

Log: Fix diskmanager-daemon.service auto-start
Bug: https://pms.uniontech.com/bug-view-245427.html