### PR TITLE
fix: Fix disk intreface display error on PGUX-L5651

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-diskmanager (1.3.34) stable; urgency=medium
+
+  * adapt to new computer models PGUX-L5651
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 26 Mar 2024 13:12:41 +0800
+
 deepin-diskmanager (1.3.33) stable; urgency=medium
 
   * update rules to disable service

--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -557,7 +557,9 @@ void DeviceStorage::getDiskInfoInterface(const QString &devicePath, QString &int
                 interface = "UFS 3.1";
             } else if (output.contains("L540")) {
                 interface = "UFS 3.1";
-            } else if (output.contains("PGUV")|| output.contains("W585")) {
+            } else if (output.contains("PGUV")
+                       || output.contains("W585")
+                       || output.contains("PGUX-L5651")) {
                 interface = "UFS 3.0";
             } else {
                 interface = "";


### PR DESCRIPTION
Adapt to new computer models PGUX-L5651.

Log: Fix disk interface display error on PGUX-L5651
Bug: https://pms.uniontech.com/bug-view-240983.html