### PR TITLE
fix: Fix disk intreface display error on PGUX

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-diskmanager (1.3.35) unstable; urgency=medium
+
+  * adapt to new computer models PGUX
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 03 Apr 2024 15:11:48 +0800
+
 deepin-diskmanager (1.3.34) stable; urgency=medium
 
   * adapt to new computer models PGUX-L5651

--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -5,6 +5,7 @@
 #include "DeviceStorage.h"
 #include <QDebug>
 #include <QFile>
+#include <QRegularExpression>
 #include "utils.h"
 
 namespace DiskManager {
@@ -557,12 +558,18 @@ void DeviceStorage::getDiskInfoInterface(const QString &devicePath, QString &int
                 interface = "UFS 3.1";
             } else if (output.contains("L540")) {
                 interface = "UFS 3.1";
-            } else if (output.contains("PGUV")
-                       || output.contains("W585")
-                       || output.contains("PGUX-L5651")) {
+            } else if (output.contains("PGUV")|| output.contains("W585")) {
                 interface = "UFS 3.0";
             } else {
                 interface = "";
+
+                Utils::executeCmdWithArtList("dmidecode", QStringList() << "-t" << "11", output, err);
+                QRegularExpression re("String 4: (.+?)\\s");
+                QRegularExpressionMatch match = re.match(output);
+                if (match.hasMatch()) {
+                    if (match.captured(1) == "PGUX")
+                        interface = "UFS 3.0";
+                }
             }
         }
         file.close();


### PR DESCRIPTION
Adapt to new computer models PGUX.

Log: Fix disk interface display error on PGUX
Bug: https://pms.uniontech.com/bug-view-240983.html