### PR TITLE
feat: Obtain disk interface info by dconfig

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -15,7 +15,7 @@ Copyright: None
 License: CC0-1.0
 
 #qrc
-Files:application/assets/appicons.qrc application/assets/resource.qrc service/diskoperation/filesystems/filesystems.pri
+Files: application/assets/appicons.qrc application/assets/resource.qrc service/diskoperation/filesystems/filesystems.pri
 Copyright: None
 License: CC0-1.0
 
@@ -25,7 +25,7 @@ Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 
 #assets
-Files: application/assets/deepin-diskmanager/*
+Files: application/assets/deepin-diskmanager/* assets/*
 Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 

--- a/assets/org.deepin.diskmanager.json
+++ b/assets/org.deepin.diskmanager.json
@@ -1,0 +1,17 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+    "diskInterface": {
+            "value": "",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Disk Interface",
+            "name[zh_CN]": "磁盘接口",
+            "description": "Disk Interface",
+            "description[zh_CN]":"磁盘接口",
+            "permissions": "readonly",
+            "visibility": "private"
+        }
+    }
+}

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(Qt5 COMPONENTS
     DBus
 REQUIRED)
 find_package(PolkitQt5-1)
+find_package(Dtk COMPONENTS Core REQUIRED)
 
 set(LINK_LIBS
     Qt5::Core
@@ -80,3 +81,13 @@ install(PROGRAMS ${APP_USBREMOVE_FILES} DESTINATION libexec/openconnect/)
 install(FILES ${APP_UDEV_FILES} DESTINATION /lib/udev/rules.d/)
 install(FILES ${APP_POLICY_FILES} DESTINATION share/polkit-1/actions)
 install(PROGRAMS ${APP_DEEPIN_DISKMANAGER_SERVICE_BIN} DESTINATION bin/)
+
+# Install dconfig meta file
+set(APPID org.deepin.diskmanager)
+set(configFile ${CMAKE_SOURCE_DIR}/assets/org.deepin.diskmanager.json)
+if (DEFINED DSG_DATA_DIR)
+    message("-- DConfig is supported by DTK")
+    dconfig_meta_files(APPID ${APPID} FILES ${configFile})
+else()
+    message("-- DConfig is NOT supported by DTK")
+endif()


### PR DESCRIPTION
When obtaining the disk interface information of the boot device of a special model, dconfig will be used directly instead of obtaining and judging the model information.

Log: remove model info