### PR TITLE
fix: adapt hard disk serial number

### DIFF
--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -236,7 +236,12 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
         m_model = mapInfo["Model Number"];
     }
 
-    setAttribute(mapInfo, "Serial Number", m_serialNumber, true);
+    if (mapInfo.find("Serial Number") != mapInfo.end())
+        setAttribute(mapInfo, "Serial Number", m_serialNumber, true);
+    else if (mapInfo.find("Serial number") != mapInfo.end()) {
+        // 某些机型smart命令查询结果为Serial number
+        setAttribute(mapInfo, "Serial number", m_serialNumber, true);
+    }
 }
 
 void DeviceStorage::setAttribute(const QMap<QString, QString> &mapInfo, const QString &key, QString &variable, bool overwrite)


### PR DESCRIPTION
  make the hard disk serial number same as deepin-devicemanger

Log: adapt hard disk serial number
Bug: https://pms.uniontech.com/bug-view-251553.html