### PR TITLE
Fix translation

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -60,7 +60,7 @@ endforeach()
 #lupdate end
 
 file (GLOB DTNG_TS_FILES translations/*.ts)
-qt5_create_translation(DTNG_QM_FILES
+qt_add_translation(DTNG_QM_FILES
     ${DTNG_TS_FILES}
      ${DTNG_QM_FILES}
      )


### PR DESCRIPTION
Deal with the following error during compilation.

```
[  9%] Built target deepin-diskmanager_app_test_autogen
/usr/bin/gmake  -f application/CMakeFiles/deepin-diskmanager.dir/build.make application/CMakeFiles/deepin-diskmanager.dir/depend
gmake[2]: Entering directory '/builddir/build/BUILD/deepin-diskmanager-1.3.36-build/deepin-diskmanager-1.3.36/redhat-linux-build'
[  9%] Generating .lupdate/deepin-diskmanager_zh_TW.ts.stamp
cd /builddir/build/BUILD/deepin-diskmanager-1.3.36-build/deepin-diskmanager-1.3.36/redhat-linux-build/application && /usr/lib64/qt5/bin/lupdate @ -ts /builddir/build/BUILD/deepin-diskmanager-1.3.36-build/deepin-diskmanager-1.3.36/application/translations/deepin-diskmanager_zh_TW.ts
lupdate error: List file '' is not readable.
gmake[2]: *** [application/CMakeFiles/deepin-diskmanager.dir/build.make:429: application/.lupdate/deepin-diskmanager_zh_TW.ts.stamp] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/deepin-diskmanager-1.3.36-build/deepin-diskmanager-1.3.36/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:343: application/CMakeFiles/deepin-diskmanager.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```

- https://sourceforge.net/p/molsketch/bugs/41/
- https://github.com/hvennekate/Molsketch/commit/e1f28e44a3f8e4eff2664beed27be691d2641e74