### PR TITLE
fix: Fix get device info fail when init

### DIFF
--- a/application/partedproxy/dmdbushandler.cpp
+++ b/application/partedproxy/dmdbushandler.cpp
@@ -203,11 +203,28 @@ QString DMDbusHandler::getRootLoginResult()
     return m_loginMessage;
 }
 
+void DMDbusHandler::getAllDevice()
+{
+    QDBusPendingCall pendingCall = m_dbus->getalldevice();
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(pendingCall);
+
+    // 连接完成信号
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished,
+        [=](QDBusPendingCallWatcher *watcher) {
+            QDBusPendingReply<> reply = *watcher;
+            if (reply.isError()) {
+                qDebug() << __FUNCTION__ << reply.error().message();
+                QTimer::singleShot(500, this, SLOT(getAllDevice()));
+            }
+            watcher->deleteLater();
+        });
+}
+
 void DMDbusHandler::getDeviceInfo()
 {
     emit showSpinerWindow(true, tr("Initializing data..."));
 
-    m_dbus->getalldevice();
+    getAllDevice();
     qDebug() << __FUNCTION__ << "-------";
 }
 

--- a/application/partedproxy/dmdbushandler.h
+++ b/application/partedproxy/dmdbushandler.h
@@ -527,6 +527,11 @@ private slots:
      */
     void onUpdateUsb();
 
+    /**
+     * @brief 触发重新请求设备信息的槽函数
+     */
+    void getAllDevice();
+
 private:
     DMDBusInterface *m_dbus = nullptr;
     static DMDbusHandler *m_staticHandeler;

--- a/application/partedproxy/dmdbusinterface.h
+++ b/application/partedproxy/dmdbusinterface.h
@@ -94,7 +94,7 @@ public Q_SLOTS: // METHODS
     /**
      * @brief 获取所有设备
      */
-    inline QDBusPendingReply<> getalldevice()
+    inline QDBusPendingCall getalldevice()
     {
         QList<QVariant> argumentList;
         return asyncCallWithArgumentList(QStringLiteral("getalldevice"), argumentList);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-diskmanager (6.0.2) unstable; urgency=medium
+
+  * new tag v6.0.2
+  * fix get device info fail when init.
+
+ -- wangrong <wangrong@uniontech.com>  Tue, 18 Mar 2025 14:21:23 +0800
+
 deepin-diskmanager (6.0.1) unstable; urgency=medium
 
   * new tag v6.0.1


### PR DESCRIPTION
When deepin-diskmanager starts, it will start deepin-diskmanager-service first, and then obtain device information from deepin-diskmanager-service. If deepin-diskmanager-service takes too long to initialize due to the existence of external storage devices, deepin-diskmanager will fail to obtain device information. At this time, deepin-diskmanager-service has not registered the dbus service.
Let's re-initiate the request after failing to obtain device information.

Log: Fix get device info fail when init
Bug: https://pms.uniontech.com/bug-view-308533.html