### PR TITLE
chore: Update CMake configuration for improved security and threading…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(deepin-diskmanager)
 
+find_package(Threads REQUIRED)
 
 option(DOTEST "option for test" OFF)
 
@@ -20,9 +21,15 @@ else()
   # -Wl, -O2 Enable linker optimizations
   # -Wl, --gc-sections Remove unused code resulting from -fdsta-sections and
   # -ffunction-sections
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2 -Wl,--gc-sections")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2 -Wl,--gc-sections")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif()
+
+# 添加位置无关代码和安全编译标志
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -fPIE")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -z relro -z now -z noexecstack -pie")
 
 set(QT_VERSION_MAJOR 6)
 if (${QT_VERSION_MAJOR} GREATER_EQUAL 6)
@@ -40,8 +47,6 @@ endif()
 #set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -fsanitize=address -O2")
 #set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -g -fsanitize=address -O2")
 #set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}  -g -fsanitize=address -O2")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all -z relro -z now -z noexecstack -pie")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -z relro -z now -z noexecstack -pie")
 
 ADD_SUBDIRECTORY(basestruct)
 ADD_SUBDIRECTORY(log)

--- a/basestruct/CMakeLists.txt
+++ b/basestruct/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::DBus
+    Threads::Threads
 )
 
 set(CMAKE_INSTALL_PREFIX /usr)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-diskmanager
 Section: tools
 Priority: optional
 Maintainer: deepin <packages@deepin.com>
-Build-Depends: debhelper (>= 11), cmake, pkg-config, qt6-tools-dev, qt6-base-dev, libx11-dev, libdtk6widget-dev,qt6-tools-dev-tools,qt6-base-private-dev, libparted-dev,libparted-fs-resize0, libpolkit-qt6-1-dev, libgtest-dev, libgmock-dev
+Build-Depends: debhelper (>= 11), cmake, pkg-config, libc6-dev, qt6-tools-dev, qt6-base-dev, libx11-dev, libdtk6widget-dev,qt6-tools-dev-tools,qt6-base-private-dev, libparted-dev,libparted-fs-resize0, libpolkit-qt6-1-dev, libgtest-dev, libgmock-dev
 Standards-Version: 4.1.3
 
 Package: deepin-diskmanager


### PR DESCRIPTION
… support

- Added required Threads package to CMakeLists.txt
- Enhanced compiler flags for position-independent code and security features
- Updated build dependencies in debian/control to include libc6-dev

## Summary by Sourcery

Update the CMake configuration to enable threading support, strengthen security compiler/linker flags, and refresh Debian build dependencies.

Enhancements:
- Require and link the Threads package in the CMake build
- Harden binaries with position-independent code, stack protector, and RELRO/now/noexecstack/PIE flags
- Refine flag usage by moving gc-sections to linker settings

Build:
- Add libc6-dev to Debian build dependencies