### PR TITLE
fix: Fix app crash when exiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 .build
 .qmake.stash
 *.qm
+
+# AI
+.cursor/
+.cursorindexingignore
+.specstory/

--- a/service/diskoperation/blockspecial.cpp
+++ b/service/diskoperation/blockspecial.cpp
@@ -79,7 +79,8 @@ BlockSpecial::BlockSpecial(const QString &name)
 
 BlockSpecial::~BlockSpecial()
 {
-    qDebug() << "BlockSpecial object destroyed for device:" << m_name;
+    // Do not log in destructors of global variables, which can cause crashes
+    // qDebug() << "BlockSpecial object destroyed for device:" << m_name;
 }
 
 void BlockSpecial::clearCache()


### PR DESCRIPTION
Do not log in destructors of global variables, which can cause crashes.

Log: Fix app crash when exiting
Bug: https://pms.uniontech.com/bug-view-322249.html

## Summary by Sourcery

Bug Fixes:
- Comment out qDebug logging in BlockSpecial::~BlockSpecial to avoid crashes during shutdown