### PR TITLE
fix: block model shows 'UnKnow'

### DIFF
--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -504,6 +504,20 @@ void DeviceStorage::getDiskInfoModel(const QString &devicePath, QString &model)
         }
     }
 
+    cmd = "udevadm info " + devicePath + " | grep ID_MODEL=";
+    proc.start("bash", QStringList() << "-c" << cmd);
+    proc.waitForFinished(-1);
+    outPut = proc.readAllStandardOutput();
+    if (!outPut.isEmpty()) {
+        auto idModel = outPut.split("=", QString::SkipEmptyParts);
+        if (idModel.count() > 1)
+            model = idModel.at(1).trimmed();
+        if (!model.isEmpty())
+            return;
+    }
+
+    qWarning() << "tried a lot but got nothing about model for" << devicePath;
+
     // 若未获取到型号名，返回未知
     model = "UnKnow";
     return;


### PR DESCRIPTION
cannot obtain model info from either smartctl nor lshw commands, try
with udevadm command to obtain ID_MODEL field.

Log: fix block model missing.

Bug: https://pms.uniontech.com/bug-view-322579.html

## Summary by Sourcery

Use udevadm to retrieve block device model as a fallback when smartctl and lshw fail, and emit a warning if still unavailable.

Bug Fixes:
- Add udevadm-based fallback to fetch the ID_MODEL field for block devices when other methods fail.

Enhancements:
- Log a warning if the device model cannot be determined after all attempts.