### PR TITLE
chore: More logs for base and service

### DIFF
--- a/basestruct/deviceinfo.cpp
+++ b/basestruct/deviceinfo.cpp
@@ -8,30 +8,32 @@
 /*********************************** stCustest          *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const stCustest &stcus)
 {
-    qDebug() << "Starting stCustest serialization";
+    // qDebug() << "Starting stCustest serialization";
     argument.beginStructure();
     argument << stcus.m_length
              << stcus.m_heads
              << stcus.m_path;
     argument.endStructure();
-    qDebug() << "Completed stCustest serialization";
+    // qDebug() << "Completed stCustest serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, stCustest &stcus)
 {
+    // qDebug() << "Starting stCustest deserialization";
     argument.beginStructure();
     argument >> stcus.m_length
              >> stcus.m_heads
              >> stcus.m_path;
 
     argument.endStructure();
+    // qDebug() << "Completed stCustest deserialization";
     return argument;
 }
 /*********************************** HardDiskInfo       *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const HardDiskInfo &inhdinfo)
 {
-    qDebug() << "Starting HardDiskInfo serialization";
+    // qDebug() << "Starting HardDiskInfo serialization";
     argument.beginStructure();
     argument << inhdinfo.m_model
              << inhdinfo.m_vendor
@@ -48,12 +50,13 @@ QDBusArgument &operator<<(QDBusArgument &argument, const HardDiskInfo &inhdinfo)
              << inhdinfo.m_firmwareVersion
              << inhdinfo.m_speed;
     argument.endStructure();
-    qDebug() << "Completed HardDiskInfo serialization";
+    // qDebug() << "Completed HardDiskInfo serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, HardDiskInfo &inhdinfo)
 {
+    // qDebug() << "Starting HardDiskInfo deserialization";
     argument.beginStructure();
     argument >> inhdinfo.m_model
              >> inhdinfo.m_vendor
@@ -70,12 +73,13 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, HardDiskInfo &inh
              >> inhdinfo.m_firmwareVersion
              >> inhdinfo.m_speed;
     argument.endStructure();
+    // qDebug() << "Completed HardDiskInfo deserialization";
     return argument;
 }
 /*********************************** HardDiskStatusInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const HardDiskStatusInfo &inhdinfo)
 {
-    qDebug() << "Starting HardDiskStatusInfo serialization";
+    // qDebug() << "Starting HardDiskStatusInfo serialization";
     argument.beginStructure();
     argument << inhdinfo.m_id
              << inhdinfo.m_attributeName
@@ -88,12 +92,12 @@ QDBusArgument &operator<<(QDBusArgument &argument, const HardDiskStatusInfo &inh
              << inhdinfo.m_whenFailed
              << inhdinfo.m_rawValue;
     argument.endStructure();
-    qDebug() << "Completed HardDiskStatusInfo serialization";
+    // qDebug() << "Completed HardDiskStatusInfo serialization";
     return argument;
 }
 const QDBusArgument &operator>>(const QDBusArgument &argument, HardDiskStatusInfo &inhdinfo)
 {
-    qDebug() << "Starting HardDiskStatusInfo deserialization";
+    // qDebug() << "Starting HardDiskStatusInfo deserialization";
     argument.beginStructure();
     argument >> inhdinfo.m_id
              >> inhdinfo.m_attributeName
@@ -107,12 +111,13 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, HardDiskStatusInf
              >> inhdinfo.m_rawValue;
     argument.endStructure();
 
-    qDebug() << "Completed HardDiskStatusInfo deserialization";
+    // qDebug() << "Completed HardDiskStatusInfo deserialization";
     return argument;
 }
 /*********************************** DeviceInfo         *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const DeviceInfo &info)
 {
+    // qDebug() << "Starting DeviceInfo serialization";
     argument.beginStructure();
     argument << info.m_length
              << info.m_heads
@@ -136,11 +141,13 @@ QDBusArgument &operator<<(QDBusArgument &argument, const DeviceInfo &info)
              << static_cast<int>(info.m_luksFlag)
              << info.m_crySupport;
     argument.endStructure();
+    // qDebug() << "Completed DeviceInfo serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, DeviceInfo &info)
 {
+    // qDebug() << "Starting DeviceInfo deserialization";
     argument.beginStructure();
     int flag = 0;
     int flag2 = 0;
@@ -168,7 +175,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, DeviceInfo &info)
     info.m_vgFlag = static_cast<LVMFlag>(flag);
     info.m_luksFlag = static_cast<LUKSFlag>(flag2);
     argument.endStructure();
-    qDebug() << "Completed DeviceInfo deserialization";
+    // qDebug() << "Completed DeviceInfo deserialization";
     return argument;
 }
 
@@ -187,7 +194,7 @@ DeviceInfo::DeviceInfo()
 /*********************************** WipeAction         *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const WipeAction &data)
 {
-    qDebug() << "Starting WipeAction serialization";
+    // qDebug() << "Starting WipeAction serialization";
     argument.beginStructure();
     argument << data.m_fstype
              << data.m_path
@@ -201,12 +208,13 @@ QDBusArgument &operator<<(QDBusArgument &argument, const WipeAction &data)
              << data.m_decryptStr
              << data.m_dmName;
     argument.endStructure();
+    // qDebug() << "Completed WipeAction serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, WipeAction &data)
 {
-    qDebug() << "Starting WipeAction deserialization";
+    // qDebug() << "Starting WipeAction deserialization";
     argument.beginStructure();
     int flag1, flag2;
     argument >> data.m_fstype
@@ -223,5 +231,6 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, WipeAction &data)
     data.m_luksFlag = static_cast<LUKSFlag>(flag1);
     data.m_crypt = static_cast<CRYPT_CIPHER>(flag2);
     argument.endStructure();
+    // qDebug() << "Completed WipeAction deserialization";
     return argument;
 }

--- a/basestruct/luksstruct.cpp
+++ b/basestruct/luksstruct.cpp
@@ -34,18 +34,18 @@ bool CRYPT_CIPHER_Support::supportAllcrypt(CRYPT_CIPHER_Support::Support x)
 
 QDBusArgument &operator<<(QDBusArgument &argument, const CRYPT_CIPHER_Support &data)
 {
-    qDebug() << "Starting CRYPT_CIPHER_Support serialization";
+    // qDebug() << "Starting CRYPT_CIPHER_Support serialization";
     argument.beginStructure();
     argument << static_cast<int>(data.aes_xts_plain64)
              << static_cast<int>(data.sm4_xts_plain64);
     argument.endStructure();
-    qDebug() << "Completed CRYPT_CIPHER_Support serialization";
+    // qDebug() << "Completed CRYPT_CIPHER_Support serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, CRYPT_CIPHER_Support &data)
 {
-    qDebug() << "Starting CRYPT_CIPHER_Support deserialization";
+    // qDebug() << "Starting CRYPT_CIPHER_Support deserialization";
     argument.beginStructure();
     int aes, sm4;
     argument >> aes
@@ -53,13 +53,13 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, CRYPT_CIPHER_Supp
     data.aes_xts_plain64 = static_cast<CRYPT_CIPHER_Support::Support>(aes);
     data.sm4_xts_plain64 = static_cast<CRYPT_CIPHER_Support::Support>(sm4);
     argument.endStructure();
-    qDebug() << "Completed CRYPT_CIPHER_Support deserialization";
+    // qDebug() << "Completed CRYPT_CIPHER_Support deserialization";
     return argument;
 }
 /*********************************** LUKS_MapperInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LUKS_MapperInfo &data)
 {
-    qDebug() << "Starting LUKS_MapperInfo serialization";
+    // qDebug() << "Starting LUKS_MapperInfo serialization";
     argument.beginStructure();
     argument << static_cast<int>(data.m_luksFs)
              << data.m_mountPoints
@@ -79,13 +79,13 @@ QDBusArgument &operator<<(QDBusArgument &argument, const LUKS_MapperInfo &data)
              << data.m_fsLimits.min_size
              << data.m_fileSystemLabel;
     argument.endStructure();
-    qDebug() << "Completed LUKS_MapperInfo serialization";
+    // qDebug() << "Completed LUKS_MapperInfo serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, LUKS_MapperInfo &data)
 {
-    qDebug() << "Starting LUKS_MapperInfo deserialization";
+    // qDebug() << "Starting LUKS_MapperInfo deserialization";
     argument.beginStructure();
     int luksFlag, vgFlag, cipher;
     argument >> luksFlag
@@ -109,13 +109,13 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LUKS_MapperInfo &
     data.m_vgflag = static_cast<LVMFlag>(vgFlag);
     data.m_crypt = static_cast<CRYPT_CIPHER>(cipher);
     argument.endStructure();
-    qDebug() << "Completed LUKS_MapperInfo deserialization";
+    // qDebug() << "Completed LUKS_MapperInfo deserialization";
     return argument;
 }
 /*********************************** LUKS_INFO *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LUKS_INFO &data)
 {
-    qDebug() << "Starting LUKS_INFO serialization";
+    // qDebug() << "Starting LUKS_INFO serialization";
     argument.beginStructure();
     argument << data.m_mapper
              << data.m_devicePath
@@ -132,13 +132,13 @@ QDBusArgument &operator<<(QDBusArgument &argument, const LUKS_INFO &data)
              << data.m_Suspend
              << data.m_fileSystemLabel;
     argument.endStructure();
-    qDebug() << "Completed LUKS_INFO serialization";
+    // qDebug() << "Completed LUKS_INFO serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, LUKS_INFO &data)
 {
-    qDebug() << "Starting LUKS_INFO deserialization";
+    // qDebug() << "Starting LUKS_INFO deserialization";
     argument.beginStructure();
     int crypt, cryptErr;
     argument >> data.m_mapper
@@ -158,26 +158,26 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LUKS_INFO &data)
     data.m_crypt = static_cast<CRYPT_CIPHER>(crypt);
     data.m_cryptErr = static_cast<CRYPTError>(cryptErr);
     argument.endStructure();
-    qDebug() << "Completed LUKS_INFO deserialization";
+    // qDebug() << "Completed LUKS_INFO deserialization";
     return argument;
 }
 /*********************************** LUKSMap ************************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LUKSMap &data)
 {
-    qDebug() << "Starting LUKSMap serialization";
+    // qDebug() << "Starting LUKSMap serialization";
     argument.beginStructure();
     argument << data.m_luksMap
              << data.m_mapper
              << static_cast<int>(data.m_cryErr)
              << data.m_cryptSuuport;
     argument.endStructure();
-    qDebug() << "Completed LUKSMap serialization";
+    // qDebug() << "Completed LUKSMap serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, LUKSMap &data)
 {
-    qDebug() << "Starting LUKSMap deserialization";
+    // qDebug() << "Starting LUKSMap deserialization";
     argument.beginStructure();
     int cryptErr;
     argument >> data.m_luksMap
@@ -186,7 +186,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LUKSMap &data)
              >> data.m_cryptSuuport;
     data.m_cryErr = static_cast<CRYPTError>(cryptErr);
     argument.endStructure();
-    qDebug() << "Completed LUKSMap deserialization";
+    // qDebug() << "Completed LUKSMap deserialization";
     return argument;
 }
 
@@ -205,6 +205,7 @@ bool LUKSMap::mapperExists(const QString &path) const
     
     foreach (const LUKS_MapperInfo &tmp, m_mapper) {
         if (tmp.m_dmPath == path) {
+            // qDebug() << "Mapper found by dmPath for path:" << path;
             return true;
         }
     }
@@ -247,8 +248,10 @@ bool LUKSMap::deviceExists(const QString &dev) const
 
 LUKS_MapperInfo LUKSMap::getMapper(const QString &path) const
 {
+    // qDebug() << "Getting mapper for path:" << path;
     foreach (const LUKS_MapperInfo &tmp, m_mapper) {
         if (tmp.m_dmPath == path || tmp.m_devicePath == path) {
+            qDebug() << "Mapper found for path:" << path;
             return tmp;
         }
     }
@@ -258,6 +261,7 @@ LUKS_MapperInfo LUKSMap::getMapper(const QString &path) const
 
 LUKS_MapperInfo LUKSMap::getMapper(const LUKS_MapperInfo &mapper) const
 {
+    // qDebug() << "Getting mapper for device path:" << mapper.m_devicePath;
     return getMapper(mapper.m_devicePath);
 }
 
@@ -271,6 +275,7 @@ bool LUKSMap::luksExists(const QString &devPath) const
 
 LUKS_INFO LUKSMap::getLUKS(const QString &path) const
 {
+    // qDebug() << "Getting LUKS for path:" << path;
     QString devicePath = deviceExists(path) ? path : getDevPath(path);
     return getItem(devicePath, m_luksMap);
 }
@@ -278,12 +283,14 @@ LUKS_INFO LUKSMap::getLUKS(const QString &path) const
 template<class T>
 bool LUKSMap::itemExists(const QString &str, const QMap<QString, T> &containers)const
 {
+    // qDebug() << "Checking existence of item:" << str;
     return containers.find(str) != containers.end();
 }
 
 template<class T>
 T LUKSMap::getItem(const QString &str, const QMap<QString, T> &containers)const
 {
+    // qDebug() << "Getting item:" << str;
     return itemExists(str, containers) ? *containers.find(str) : T();
 }
 

--- a/basestruct/lvmstruct.cpp
+++ b/basestruct/lvmstruct.cpp
@@ -9,18 +9,22 @@
 /*********************************** PVData *********************************************/
 bool PVData::operator<(const PVData &tmp) const
 {
+    // qDebug() << "Entering PVData::operator<";
     if (m_type == DevType::DEV_UNALLOCATED_PARTITION) {
+        // qDebug() << "Comparing unallocated partition";
         return m_devicePath     < tmp.m_devicePath
                || m_startSector < tmp.m_startSector
                || m_endSector   < tmp.m_endSector
                || m_diskPath    < tmp.m_diskPath
                || m_sectorSize  < tmp.m_sectorSize;
     }
+    // qDebug() << "Comparing allocated partition";
     return m_devicePath < tmp.m_devicePath || m_diskPath < tmp.m_diskPath;
 }
 
 bool PVData::operator==(const PVData &tmp) const
 {
+    // qDebug() << "Entering PVData::operator==";
     return m_devicePath     == tmp.m_devicePath
            && m_startSector == tmp.m_startSector
            && m_endSector   == tmp.m_endSector
@@ -32,6 +36,7 @@ bool PVData::operator==(const PVData &tmp) const
 
 QDBusArgument &operator<<(QDBusArgument &argument, const PVData &data)
 {
+    // qDebug() << "Entering operator<< for PVData";
     argument.beginStructure();
     argument << data.m_devicePath
              << data.m_startSector
@@ -46,6 +51,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const PVData &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, PVData &data)
 {
+    // qDebug() << "Entering operator>> for PVData";
     argument.beginStructure();
     int pvAct, type;
     argument >> data.m_devicePath
@@ -63,6 +69,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, PVData &data)
 /*********************************** CreateLVInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LVAction &data)
 {
+    // qDebug() << "Entering operator<< for LVAction";
     argument.beginStructure();
     argument << data.m_vgName
              << data.m_lvName
@@ -84,6 +91,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const LVAction &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, LVAction &data)
 {
+    // qDebug() << "Entering operator>> for LVAction";
     argument.beginStructure();
     int type, act, luksFlag, crypt;
     argument >> data.m_vgName
@@ -110,6 +118,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LVAction &data)
 /*********************************** LVDATA *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LVData &data)
 {
+    // qDebug() << "Entering operator<< for LVData";
     argument.beginStructure();
     argument << data.m_lvName
              << data.m_lvPath
@@ -121,6 +130,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const LVData &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, LVData &data)
 {
+    // qDebug() << "Entering operator>> for LVData";
     argument.beginStructure();
     argument >> data.m_lvName
              >> data.m_lvPath
@@ -132,6 +142,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LVData &data)
 /*********************************** VGDATA *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const VGData &data)
 {
+    // qDebug() << "Entering operator<< for VGData";
     argument.beginStructure();
     argument << data.m_vgName
              << data.m_vgSize
@@ -144,6 +155,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const VGData &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, VGData &data)
 {
+    // qDebug() << "Entering operator>> for VGData";
     argument.beginStructure();
     argument >> data.m_vgName
              >> data.m_vgSize
@@ -156,6 +168,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, VGData &data)
 /*********************************** PVRANGES *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const PVRanges &data)
 {
+    // qDebug() << "Entering operator<< for PVRanges";
     argument.beginStructure();
     argument << data.m_lvName
              << data.m_devPath
@@ -170,6 +183,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const PVRanges &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, PVRanges &data)
 {
+    // qDebug() << "Entering operator>> for PVRanges";
     argument.beginStructure();
     argument >> data.m_lvName
              >> data.m_devPath
@@ -184,6 +198,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, PVRanges &data)
 /*********************************** PVInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const PVInfo &data)
 {
+    // qDebug() << "Entering operator<< for PVInfo";
     argument.beginStructure();
     argument << data.m_pvFmt
              << data.m_vgName
@@ -210,6 +225,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const PVInfo &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument,  PVInfo &data)
 {
+    // qDebug() << "Entering operator>> for PVInfo";
     argument.beginStructure();
     int err, devType;
     argument >> data.m_pvFmt
@@ -239,6 +255,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument,  PVInfo &data)
 /*********************************** LVInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LVInfo &data)
 {
+    // qDebug() << "Entering operator<< for LVInfo";
     argument.beginStructure();
     argument << data.m_vgName
              << data.m_lvPath
@@ -266,6 +283,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const LVInfo &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, LVInfo &data)
 {
+    // qDebug() << "Entering operator>> for LVInfo";
     argument.beginStructure();
     int err, type, luksFlag;
     argument >> data.m_vgName
@@ -297,6 +315,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LVInfo &data)
 /*********************************** VGInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const VGInfo &data)
 {
+    // qDebug() << "Entering operator<< for VGInfo";
     argument.beginStructure();
     argument << data.m_vgName
              << data.m_vgUuid
@@ -320,6 +339,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const VGInfo &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument,  VGInfo &data)
 {
+    // qDebug() << "Entering operator>> for VGInfo";
     argument.beginStructure();
     int err, luksFlag;
     argument >> data.m_vgName
@@ -369,8 +389,10 @@ bool VGInfo::lvInfoExists(const QString &lvName)
 
 bool VGInfo::isAllPV(QVector<QString> pvList) const
 {
+    qDebug() << "VGInfo::isAllPV - Checking pvList:" << pvList;
     QVector<QString> list = m_pvInfo.keys().toVector();
     if (pvList.size() < list.size()) {
+        qDebug() << "PV count mismatch";
         return false;
     }
 
@@ -381,6 +403,7 @@ bool VGInfo::isAllPV(QVector<QString> pvList) const
 /*********************************** LVMInfo *********************************************/
 QDBusArgument &operator<<(QDBusArgument &argument, const LVMInfo &data)
 {
+    // qDebug() << "Entering operator<< for LVMInfo";
     argument.beginStructure();
     argument << data.m_pvInfo
              << data.m_vgInfo
@@ -391,6 +414,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const LVMInfo &data)
 
 const QDBusArgument &operator>>(const QDBusArgument &argument,  LVMInfo &data)
 {
+    // qDebug() << "Entering operator>> for LVMInfo";
     argument.beginStructure();
     int err;
     argument >> data.m_pvInfo
@@ -451,15 +475,19 @@ VGInfo LVMInfo::getVG(const QString &vgName)
 
 VGInfo LVMInfo::getVG(const PVData &pv)
 {
+    qDebug() << "LVMInfo::getVG - Enter";
     if (pvExists(pv)) {
+        qDebug() << "PV exists, getting PV info";
         PVInfo info = getPV(pv);
         return getVG(info.m_vgName);
     }
+    qDebug() << "PV does not exist, returning empty VGInfo";
     return VGInfo();
 }
 
 VGInfo LVMInfo::getVG(const PVInfo &pv)
 {
+    // qDebug() << "LVMInfo::getVG - Enter";
     return getVG(pv.m_vgName);
 }
 
@@ -471,26 +499,31 @@ PVInfo LVMInfo::getPV(const QString &pvPath)
 
 PVInfo LVMInfo::getPV(const PVData &pv)
 {
+    // qDebug() << "LVMInfo::getPV - Enter, pv:" << pv;
     return getPV(pv.m_devicePath);
 }
 
 QVector<PVInfo> LVMInfo::getVGAllPV(const QString &vgName)
 {
+    // qDebug() << "LVMInfo::getVGAllPV - Enter, vgName:" << vgName;
     return vgExists(vgName) ? getVG(vgName).m_pvInfo.values().toVector() : QVector<PVInfo>();
 }
 
 QVector<PVInfo> LVMInfo::getVGAllUsedPV(const QString &vgName)
 {
+    // qDebug() << "LVMInfo::getVGAllUsedPV - Enter, vgName:" << vgName;
     return getVGPVList(vgName, true);
 }
 
 QVector<PVInfo> LVMInfo::getVGAllUnUsedPV(const QString &vgName)
 {
+    // qDebug() << "LVMInfo::getVGAllUnUsedPV - Enter, vgName:" << vgName;
     return getVGPVList(vgName, false);
 }
 
 QList<QString> LVMInfo::getVGOfDisk(const QString &vgName, const QString &disk)
 {
+    qDebug() << "LVMInfo::getVGOfDisk - Enter, vgName:" << vgName << "disk:" << disk;
     QList<QString>list;
     foreach (auto it, m_pvInfo) {
         //todo 要对这里进行优化 目前是比较是否包含磁盘路径字符串
@@ -498,18 +531,23 @@ QList<QString> LVMInfo::getVGOfDisk(const QString &vgName, const QString &disk)
             list.push_back(it.m_pvPath);
         }
     }
+    qDebug() << "LVMInfo::getVGOfDisk - Exiting, list:" << list;
     return list;
 }
 
 QVector<PVInfo> LVMInfo::getVGPVList(const QString &vgName, bool isUsed)
 {
+    qDebug() << "Entering LVMInfo::getVGPVList for VG:" << vgName << "isUsed:" << isUsed;
     QVector<PVInfo> pvList;
     if (vgExists(vgName)) {
+        qDebug() << "VG exists, getting PV list";
         VGInfo vg = getVG(vgName);
         foreach (const PVInfo &pv, vg.m_pvInfo) {
             if (isUsed && pv.m_pvUsedPE > 0) {
+                qDebug() << "Checking if PV is used:" << pv.m_pvPath;
                 pvList.push_back(pv);
             } else if (!isUsed && pv.m_pvUsedPE == 0) {
+                qDebug() << "PV is not checked for usage, adding to list";
                 pvList.push_back(pv);
             }
         }
@@ -540,6 +578,7 @@ bool LVMInfo::lvInfoExists(const QString &lvPath)
     }
 
     if (lvPath.contains("/dev/mapper/")) {
+        qDebug() << "LVMInfo::lvInfoExists - Checking lvPath in mapper path:" << lvPath;
         QStringList list2 = list[2].split("-");
         if (!vgExists(list2[0])) {
             qWarning() << "LVMInfo::lvInfoExists - VG not found in mapper path:" << lvPath;
@@ -549,6 +588,7 @@ bool LVMInfo::lvInfoExists(const QString &lvPath)
         VGInfo vg =  getVG(list2[0]);
         foreach (LVInfo lv, vg.m_lvlist) {
             if ("/dev/mapper/" + vg.m_vgName + "-" + lv.m_lvName == lvPath) {
+                qDebug() << "LVMInfo::lvInfoExists - LV found in mapper path:" << lvPath;
                 return true;
             }
         }
@@ -572,22 +612,27 @@ bool LVMInfo::pvExists(const QString &pvPath)
 
 bool LVMInfo::vgExists(const PVData &pv)
 {
+    // qDebug() << "LVMInfo::vgExists - Checking pv:" << pv;
     return pvExists(pv) ? vgExists(getPV(pv).m_vgName) : false;
 }
 
 bool LVMInfo::vgExists(const PVInfo &pv)
 {
+    // qDebug() << "LVMInfo::vgExists - Checking pv:" << pv;
     return vgExists(pv.m_vgName);
 }
 
 bool LVMInfo::pvExists(const PVData &pv)
 {
+    // qDebug() << "LVMInfo::pvExists - Checking pv:" << pv;
     return pvExists(pv.m_devicePath);
 }
 
 bool LVMInfo::pvOfVg(const QString &vgName, const QString &pvPath)
 {
+    qDebug() << "LVMInfo::pvOfVg - Enter, vgName:" << vgName << "pvPath:" << pvPath;
     if (!vgExists(vgName)) {
+        qDebug() << "LVMInfo::pvOfVg - VG not found:" << vgName;
         return false;
     }
 
@@ -597,37 +642,44 @@ bool LVMInfo::pvOfVg(const QString &vgName, const QString &pvPath)
 
 bool LVMInfo::pvOfVg(const QString &vgName, const PVData &pv)
 {
+    qDebug() << "LVMInfo::pvOfVg - Checking vgName:" << vgName;
     return pvOfVg(vgName, pv.m_devicePath);
 }
 
 bool LVMInfo::pvOfVg(const PVInfo &pv)
 {
+    // qDebug() << "LVMInfo::pvOfVg - Checking pv:" << pv;
     return pvOfVg(pv.m_vgName, pv.m_pvPath);
 }
 
 bool LVMInfo::pvOfVg(const VGInfo &vg, const PVInfo &pv)
 {
+    // qDebug() << "LVMInfo::pvOfVg - Checking pv:" << pv << "vg:" << vg;
     return pvOfVg(vg.m_vgName, pv.m_pvPath);
 }
 
 bool LVMInfo::pvOfVg(const VGInfo &vg, const PVData &pv)
 {
+    // qDebug() << "LVMInfo::pvOfVg - Checking pv:" << pv << "vg:" << vg;
     return pvOfVg(vg.m_vgName, pv.m_devicePath);
 }
 
 bool LVMInfo::pvOfVg(const QString &vgName, const PVInfo &pv)
 {
+    // qDebug() << "LVMInfo::pvOfVg - Checking pv:" << pv << "vgName:" << vgName;
     return pvOfVg(vgName, pv.m_pvPath);
 }
 
 template<class T>
 T LVMInfo:: getItem(const QString &str,  const QMap<QString, T> &containers)
 {
+    // qDebug() << "LVMInfo::getItem - Enter, str:" << str << "containers:" << containers;
     return itemExists(str, containers) ? *containers.find(str) : T();
 }
 
 template<class T>
 bool LVMInfo::itemExists(const QString &str, const QMap<QString, T> &containers)
 {
+    // qDebug() << "LVMInfo::itemExists - Enter, str:" << str << "containers:" << containers;
     return containers.find(str) != containers.end();
 }

--- a/basestruct/partitioninfo.cpp
+++ b/basestruct/partitioninfo.cpp
@@ -26,32 +26,38 @@ PartitionInfo::PartitionInfo()
 Sector PartitionInfo::getSectorLength() const
 {
     qDebug() << "PartitionInfo::getSectorLength";
-    if (m_sectorStart >= 0 && m_sectorEnd >= 0)
+    if (m_sectorStart >= 0 && m_sectorEnd >= 0) {
+        qDebug() << "PartitionInfo::getSectorLength - Valid sector range";
         return m_sectorEnd - m_sectorStart + 1;
-    else
+    } else {
+        qWarning() << "PartitionInfo::getSectorLength - Invalid sector range";
         return -1;
+    }
 }
 
 Byte_Value PartitionInfo::getByteLength() const
 {
     qDebug() << "PartitionInfo::getByteLength";
-    if (getSectorLength() >= 0)
+    if (getSectorLength() >= 0) {
+        qDebug() << "PartitionInfo::getByteLength - Valid sector range";
         return getSectorLength() * m_sectorSize;
-    else
+    } else {
+        qWarning() << "PartitionInfo::getByteLength - Invalid sector range";
         return -1;
+    }
 }
 
 bool PartitionInfo::operator==(const PartitionInfo &info) const
 {
-    qDebug() << "PartitionInfo::operator==";
+    // qDebug() << "PartitionInfo::operator==";
     return m_devicePath == info.m_devicePath && m_partitionNumber == info.m_partitionNumber && m_sectorStart == info.m_sectorStart && m_type == info.m_type;
 }
 
 QDBusArgument &operator<<(QDBusArgument &argument, const PartitionInfo &info)
 {
-    qDebug() << "Starting PartitionInfo serialization";
+    // qDebug() << "Starting PartitionInfo serialization";
     argument.beginStructure();
-    qDebug() << "Serializing PartitionInfo fields";
+    // qDebug() << "Serializing PartitionInfo fields";
     argument << info.m_devicePath
              << info.m_partitionNumber
              << info.m_type
@@ -86,15 +92,15 @@ QDBusArgument &operator<<(QDBusArgument &argument, const PartitionInfo &info)
              << info.m_decryptStr
              << info.m_dmName;;
     argument.endStructure();
-    qDebug() << "Completed PartitionInfo serialization";
+    // qDebug() << "Completed PartitionInfo serialization";
     return argument;
 }
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, PartitionInfo &info)
 {
-    qDebug() << "Starting PartitionInfo deserialization";
+    // qDebug() << "Starting PartitionInfo deserialization";
     argument.beginStructure();
-    qDebug() << "Deserializing PartitionInfo fields";
+    // qDebug() << "Deserializing PartitionInfo fields";
     int flag = 0;
     int flag2 = 0;
     int crypt = 0;
@@ -135,6 +141,6 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, PartitionInfo &in
     info.m_luksFlag = static_cast<LUKSFlag>(flag2);
     info.m_crypt = static_cast<CRYPT_CIPHER>(crypt);
     argument.endStructure();
-    qDebug() << "Completed PartitionInfo deserialization";
+    // qDebug() << "Completed PartitionInfo deserialization";
     return argument;
 }

--- a/basestruct/utils.cpp
+++ b/basestruct/utils.cpp
@@ -25,8 +25,10 @@ Utils::Utils()
 QString Utils::findProgramInPath(const QString &proName)
 {
     qDebug() << "Utils::findProgramInPath----" << proName;
-    if (proName.isEmpty())
+    if (proName.isEmpty()) {
+        // qDebug() << "Program name is empty";
         return QString();
+    }
     QStringList strArg;
     strArg << proName;
     QString strOut, strerr;
@@ -79,16 +81,19 @@ int Utils::executCmd(const QString &strCmd, QString &outPut, QString &error)
     QStringList argList;
     for (int i = 1; i < cmdList.size(); i++) {
         if (!cmdList[i].isEmpty()) {
+            qDebug() << "Appending argument:" << cmdList[i];
             argList.append(cmdList[i]);
         }
     }
     int exitcode = executeCmdWithArtList(cmdList[0], argList, outPut, error);
 
+    qDebug() << "Utils::executCmd exitcode:  " << exitcode;
     return exitcode;
 }
 
 int Utils::executWithInputOutputCmd(const QString &strCmdArg, const QString *inPut, QString &outPut, QString &error)
 {
+    qDebug() << "Entering Utils::executWithInputOutputCmd with command:" << strCmdArg;
     QProcess proc;
     int exitCode;
 
@@ -99,6 +104,7 @@ int Utils::executWithInputOutputCmd(const QString &strCmdArg, const QString *inP
 #endif
 
     if (inPut) {
+        qDebug() << "Writing input to process:" << *inPut;
         proc.waitForStarted(-1);
         proc.write(inPut->toLocal8Bit());
         proc.closeWriteChannel();
@@ -110,6 +116,7 @@ int Utils::executWithInputOutputCmd(const QString &strCmdArg, const QString *inP
     exitCode = proc.exitCode();
     proc.close();
 
+    qDebug() << "Utils::executWithInputOutputCmd exitCode:  " << exitCode;
     return exitCode;
 }
 
@@ -134,37 +141,46 @@ int Utils::executWithErrorCmd(const QString &strCmd, const QStringList &strArg, 
 
 QString Utils::regexpLabel(const QString &strText, const QString &strPatter)
 {
+    qDebug() << "Utils::regexpLabel strText:  " << strText << "strPatter:  " << strPatter;
     QString strSource = strText;
     QString result;
     QRegularExpression re(strPatter, QRegularExpression::MultilineOption | QRegularExpression::CaseInsensitiveOption);
     QRegularExpressionMatch match = re.match(strSource);
     if (match.isValid() && match.hasMatch()) {
+        qDebug() << "Regexp match found";
         for (int i = 0; i <= match.lastCapturedIndex(); i++) {
             result = match.captured(i);
-//            qDebug() << __FUNCTION__ << "-------****" << result;
+            qDebug() << "Captured result:" << result;
             break;
         }
     }
+    qDebug() << "Utils::regexpLabel result:  " << result;
     return result;
 }
 
 const QString Utils::getPartitionTypeString(PartitionType type)
 {
+    qDebug() << "Entering Utils::getPartitionTypeString for type:" << type;
     QString strType;
     switch (type) {
     case TYPE_PRIMARY:
+        qDebug() << "Partition type is Primary";
         strType = "Primary";
         break;
     case TYPE_LOGICAL:
+        qDebug() << "Partition type is Logical";
         strType = "Logical";
         break;
     case TYPE_EXTENDED:
+        qDebug() << "Partition type is Extended";
         strType = "Extended";
         break;
     case TYPE_UNALLOCATED:
+        qDebug() << "Partition type is Unallocated";
         strType = "Unallocated";
         break;
     case TYPE_UNPARTITIONED:
+        qDebug() << "Partition type is Unpartitioned";
         strType = "Unpartitioned";
         break;
     }
@@ -173,12 +189,15 @@ const QString Utils::getPartitionTypeString(PartitionType type)
 
 const QString Utils::fileSystemTypeToString(FSType type)
 {
+    qDebug() << "Entering Utils::fileSystemTypeToString for type:" << type;
     QString strFileSystemType;
     switch (type) {
     case FS_UNSUPPORTED:
+        qDebug() << "Filesystem type is Unsupported";
         strFileSystemType = "unsupported";
         break;
     case FS_UNALLOCATED:
+        qDebug() << "Filesystem type is Unallocated";
         /* TO TRANSLATORS:  unallocated
          * means that this space on the disk device is
          * outside any partition, so is in other words
@@ -187,6 +206,7 @@ const QString Utils::fileSystemTypeToString(FSType type)
         strFileSystemType = "unallocated";
         break;
     case FS_UNKNOWN:
+        qDebug() << "Filesystem type is Unknown";
         /* TO TRANSLATORS:  unknown
          * means that this space within this partition does
          * not contain a file system known to GParted, and
@@ -195,6 +215,7 @@ const QString Utils::fileSystemTypeToString(FSType type)
         strFileSystemType = "unknown";
         break;
     case FS_UNFORMATTED:
+        qDebug() << "Filesystem type is Unformatted";
         /* TO TRANSLATORS:  unformatted
          * means that when the new partition is created by
          * GParted the space within it will not be formatted
@@ -203,6 +224,7 @@ const QString Utils::fileSystemTypeToString(FSType type)
         strFileSystemType = "unformatted";
         break;
     case FS_OTHER:
+        qDebug() << "Filesystem type is Other";
         /* TO TRANSLATORS:  other
          * name shown in the File System Support dialog to list
          * actions which can be performed on other file systems
@@ -211,6 +233,7 @@ const QString Utils::fileSystemTypeToString(FSType type)
         strFileSystemType = "other";
         break;
     case FS_CLEARED:
+        qDebug() << "Filesystem type is Cleared";
         /* TO TRANSLATORS:  cleared
          * means that all file system signatures in the partition
          * will be cleared by GParted.
@@ -218,111 +241,147 @@ const QString Utils::fileSystemTypeToString(FSType type)
         strFileSystemType = "cleared";
         break;
     case FS_EXTENDED:
+        qDebug() << "Filesystem type is Extended";
         strFileSystemType = "extended";
         break;
     case FS_BTRFS:
+        qDebug() << "Filesystem type is BTRFS";
         strFileSystemType = "btrfs";
         break;
     case FS_EXFAT:
+        qDebug() << "Filesystem type is exFAT";
         strFileSystemType = "exfat";
         break;
     case FS_EXT2:
+        qDebug() << "Filesystem type is ext2";
         strFileSystemType = "ext2";
         break;
     case FS_EXT3:
+        qDebug() << "Filesystem type is ext3";
         strFileSystemType = "ext3";
         break;
     case FS_EXT4:
+        qDebug() << "Filesystem type is ext4";
         strFileSystemType = "ext4";
         break;
     case FS_F2FS:
+        qDebug() << "Filesystem type is f2fs";
         strFileSystemType = "f2fs";
         break;
     case FS_FAT16:
+        qDebug() << "Filesystem type is FAT16";
         strFileSystemType = "fat16";
         break;
     case FS_FAT32:
+        qDebug() << "Filesystem type is FAT32";
         strFileSystemType = "fat32";
         break;
     case FS_HFS:
+        qDebug() << "Filesystem type is HFS";
         strFileSystemType = "hfs";
         break;
     case FS_HFSPLUS:
+        qDebug() << "Filesystem type is HFS+";
         strFileSystemType = "hfs+";
         break;
     case FS_JFS:
+        qDebug() << "Filesystem type is JFS";
         strFileSystemType = "jfs";
         break;
     case FS_LINUX_SWAP:
+        qDebug() << "Filesystem type is Linux Swap";
         strFileSystemType = "linux-swap";
         break;
     case FS_LUKS:
+        qDebug() << "Filesystem type is LUKS";
         strFileSystemType = "luks";
         break;
     case FS_LVM2_PV:
+        qDebug() << "Filesystem type is LVM2 PV";
         strFileSystemType = "lvm2 pv";
         break;
     case FS_MINIX:
+        qDebug() << "Filesystem type is MINIX";
         strFileSystemType = "minix";
         break;
     case FS_NILFS2:
+        qDebug() << "Filesystem type is NILFS2";
         strFileSystemType = "nilfs2";
         break;
     case FS_NTFS:
+        qDebug() << "Filesystem type is NTFS";
         strFileSystemType = "ntfs";
         break;
     case FS_REISER4:
+        qDebug() << "Filesystem type is Reiser4";
         strFileSystemType = "reiser4";
         break;
     case FS_REISERFS:
+        qDebug() << "Filesystem type is ReiserFS";
         strFileSystemType = "reiserfs";
         break;
     case FS_UDF:
+        qDebug() << "Filesystem type is UDF";
         strFileSystemType = "udf";
         break;
     case FS_XFS:
+        qDebug() << "Filesystem type is XFS";
         strFileSystemType = "xfs";
         break;
     case FS_APFS:
+        qDebug() << "Filesystem type is APFS";
         strFileSystemType = "apfs";
         break;
     case FS_ATARAID:
+        qDebug() << "Filesystem type is ATARAID";
         strFileSystemType = "ataraid";
         break;
     case FS_BITLOCKER:
+        qDebug() << "Filesystem type is BITLOCKER";
         strFileSystemType = "bitlocker";
         break;
     case FS_GRUB2_CORE_IMG:
+        qDebug() << "Filesystem type is GRUB2_CORE_IMG";
         strFileSystemType = "grub2 core.img";
         break;
     case FS_ISO9660:
+        qDebug() << "Filesystem type is ISO9660";
         strFileSystemType = "iso9660";
         break;
     case FS_LINUX_SWRAID:
+        qDebug() << "Filesystem type is Linux SWRAID";
         strFileSystemType = "linux-raid";
         break;
     case FS_LINUX_SWSUSPEND:
+        qDebug() << "Filesystem type is Linux SWSUSPEND";
         strFileSystemType = "linux-suspend";
         break;
     case FS_REFS:
+        qDebug() << "Filesystem type is REFS";
         strFileSystemType = "refs";
         break;
     case FS_UFS:
+        qDebug() << "Filesystem type is UFS";
         strFileSystemType = "ufs";
         break;
     case FS_ZFS:
+        qDebug() << "Filesystem type is ZFS";
         strFileSystemType = "zfs";
         break;
     case FS_USED:
+        qDebug() << "Filesystem type is Used";
         strFileSystemType = "used";
         break;
     case FS_UNUSED:
+        qDebug() << "Filesystem type is Unused";
         strFileSystemType = "unused";
         break;
     default:
+        qDebug() << "Filesystem type is Unknown";
         strFileSystemType = "";
     }
 
+    qDebug() << "Converted filesystem type:" << strFileSystemType;
     return strFileSystemType;
 }
 
@@ -417,6 +476,7 @@ int Utils::getMountedFileSystemUsage(const QString &mountpoint, Byte_Value &file
 
 QString Utils::getFileSystemSoftWare(FSType fileSystemType)
 {
+    qDebug() << "Utils::getFileSystemSoftWare - Checking:" << fileSystemType;
     switch (fileSystemType) {
     case FS_BTRFS:
         return "btrfs.h-progs / btrfs.h-tools";
@@ -462,6 +522,7 @@ QString Utils::getFileSystemSoftWare(FSType fileSystemType)
     default:
         return "";
     }
+    qDebug() << "Utils::getFileSystemSoftWare - return empty";
     return "";
 }
 
@@ -485,11 +546,13 @@ QString Utils::formatSize(Sector sectors, Byte_Value sectorSize)
         res = res.setNum(sectorToUnit(sectors, sectorSize, UNIT_TIB), 'f', 2);
         res.append(" TiB");
     }
+    qDebug() << "Utils::formatSize - Formatted size:" << res;
     return res;
 }
 
 double Utils::sectorToUnit(Sector sectors, Byte_Value sectorSize, SIZE_UNIT sizeUnit)
 {
+    qDebug() << "Utils::sectorToUnit - Converting sectors:" << sectors << "sectorSize:" << sectorSize << "sizeUnit:" << sizeUnit;
     double res = 0.0;
     switch (sizeUnit) {
     case UNIT_BYTE:
@@ -510,11 +573,13 @@ double Utils::sectorToUnit(Sector sectors, Byte_Value sectorSize, SIZE_UNIT size
     default:
         res = sectors;
     }
+    qDebug() << "Utils::sectorToUnit - Converted value:" << res;
     return res;
 }
 
 int Utils::getMaxPartitionNameLength(QString &tableType)
 {
+    qDebug() << "Utils::getMaxPartitionNameLength - Checking tableType:" << tableType;
     if (tableType == "amiga")
         return 0; // Disabled
     else if (tableType == "dvh")
@@ -526,21 +591,25 @@ int Utils::getMaxPartitionNameLength(QString &tableType)
     else if (tableType == "pc98")
         return 0; // Disabled
 
+    qDebug() << "Utils::getMaxPartitionNameLength - Returning 0";
     return 0;
 }
 
 Byte_Value Utils::floorSize(Byte_Value value, Byte_Value roundingSize)
 {
+    // qInfo() << "Utils::floorSize - value:" << value << "roundingSize:" << roundingSize;
     return value / roundingSize * roundingSize;
 }
 
 Byte_Value Utils::ceilSize(Byte_Value value, Byte_Value roundingSize)
 {
+    // qInfo() << "Utils::ceilSize - value:" << value << "roundingSize:" << roundingSize;
     return (value + roundingSize - 1LL) / roundingSize * roundingSize;
 }
 
 QString Utils::createUuid()
 {
+    qInfo() << "Utils::createUuid - Creating UUID";
     QUuid uuid;
     return uuid.createUuid().toString(QUuid::WithoutBraces);
 }
@@ -548,6 +617,7 @@ QString Utils::createUuid()
 
 QString Utils::LVMFormatSize(long long lvmSize)
 {
+    qInfo() << "Utils::LVMFormatSize - Formatting size for lvmSize:" << lvmSize;
     QString res;
     if (lvmSize  < KIBIBYTE) {
         res = res.setNum(LVMSizeToUnit(lvmSize, UNIT_BYTE), 'f', 2);
@@ -565,11 +635,13 @@ QString Utils::LVMFormatSize(long long lvmSize)
         res = res.setNum(LVMSizeToUnit(lvmSize, UNIT_TIB), 'f', 2);
         res.append(" TiB");
     }
+    qInfo() << "Utils::LVMFormatSize - Formatted size:" << res;
     return res;
 }
 
 double Utils::LVMSizeToUnit(long long lvmSize, SIZE_UNIT sizeUnit)
 {
+    qInfo() << "Utils::LVMSizeToUnit - Converting lvmSize:" << lvmSize << "sizeUnit:" << sizeUnit;
     double res = 0.0;
     switch (sizeUnit) {
     case UNIT_BYTE:
@@ -590,11 +662,13 @@ double Utils::LVMSizeToUnit(long long lvmSize, SIZE_UNIT sizeUnit)
     default:
         res = lvmSize;
     }
+    qInfo() << "Utils::LVMSizeToUnit - Converted value:" << res;
     return res;
 }
 
 bool Utils::adjudicationPVDelete(LVMInfo lvmInfo, const set<QString> &pvStrList, bool &bigDataMove, QStringList &realMovePvList)
 {
+    qDebug() << "Entering Utils::adjudicationPVDelete";
     bigDataMove = false;
     //获取所有存在于vg中 待删除的pv
     QMap<QString, QVector<QString>>t_map;
@@ -609,6 +683,7 @@ bool Utils::adjudicationPVDelete(LVMInfo lvmInfo, const set<QString> &pvStrList,
         }
 
         if (!lvmInfo.pvOfVg(pv)) {      //vg不存在或pv不在vg中 说明数据有错误
+            qWarning() << "pv not join vg";
             return false;
         }
         t_map[pv.m_vgName].push_back(pv.m_pvPath);
@@ -631,19 +706,23 @@ bool Utils::adjudicationPVDelete(LVMInfo lvmInfo, const set<QString> &pvStrList,
             }
         }
         if (vgInfo.m_peUnused - unusedPE < remvoePE) { //判断是否允许删除
+            qWarning() << "pv used pe more than vg unused pe";
             return false;
         }
 
         if (!bigDataMove) { //判断是否存在大量数据需要移动
+            qInfo() << "Utils::adjudicationPVDelete - Checking if large data move is needed";
             remvoeAllSize += (remvoePE * vgInfo.m_PESize);
             bigDataMove = ((remvoeAllSize / GIBIBYTE) >= 1);
         }
     }
+    qInfo() << "Utils::adjudicationPVDelete return true";
     return true;
 }
 
 QString Utils::getCipherStr(CRYPT_CIPHER cipher)
 {
+    qDebug() << "Entering Utils::getCipherStr for cipher:" << cipher;
     switch (cipher) {
     case CRYPT_CIPHER::NOT_CRYPT:
         return QString("not_crypt");
@@ -658,6 +737,7 @@ QString Utils::getCipherStr(CRYPT_CIPHER cipher)
 
 CRYPT_CIPHER Utils::getCipher(QString cipher)
 {
+    qDebug() << "Entering Utils::getCipher for cipher:" << cipher;
     if (cipher.contains("not_crypt")) {
         return  CRYPT_CIPHER::NOT_CRYPT;
     } else if (cipher.contains("aes-xts-plain64")) {
@@ -741,9 +821,3 @@ int Utils::executCmd(const QString &strCmd)
     proc.close();
     return exitcode;
 }
-
-
-
-
-
-

--- a/service/diskmanagerservice.cpp
+++ b/service/diskmanagerservice.cpp
@@ -23,6 +23,7 @@ DiskManagerService::DiskManagerService(const QString &frontEndDBusName, QObject 
 
 void DiskManagerService::initConnection()
 {
+    qDebug() << "Entering DiskManagerService::initConnection";
     connect(m_partedcore, &PartedCore::updateDeviceInfo, this, &DiskManagerService::updateDeviceInfo);
     connect(m_partedcore, &PartedCore::updateLUKSInfo, this, &DiskManagerService::updateLUKSInfo);
     connect(m_partedcore, &PartedCore::deletePartitionMessage, this, &DiskManagerService::deletePartition);
@@ -47,8 +48,11 @@ void DiskManagerService::initConnection()
 
 void DiskManagerService::Quit()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::Quit";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for Quit";
         return;
+    }
 
     qDebug() << "DiskManagerService::Quit called";
     m_partedcore->delTempMountFile();
@@ -69,8 +73,11 @@ void DiskManagerService::Quit()
 //}
 void DiskManagerService::Start()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::Start";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for Start";
         return;
+    }
 
     QString msg = "DiskManagerService::Start called";
     Q_EMIT MessageReport(msg);
@@ -78,6 +85,7 @@ void DiskManagerService::Start()
 
 DeviceInfo DiskManagerService::getDeviceinfo()
 {
+    qDebug() << "Entering DiskManagerService::getDeviceinfo";
     if (!checkAuthorization()) {
         qWarning() << "Authorization failed for getDeviceinfo";
         return DeviceInfo();
@@ -92,8 +100,11 @@ DeviceInfo DiskManagerService::getDeviceinfo()
 //TODO： 这里感觉没有必要发送信号 等之后有时间测试一下 能否去掉多余的代码
 void DiskManagerService::getalldevice()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::getalldevice";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for getalldevice";
         return;
+    }
 
 //    qDebug() << "DiskManagerService::getalldevice";
 //    DeviceInfoMap infores = m_partedcore->getAllDeviceinfo();
@@ -103,6 +114,7 @@ void DiskManagerService::getalldevice()
 
 void DiskManagerService::onGetAllDeviceInfomation()
 {
+    qDebug() << "Entering DiskManagerService::onGetAllDeviceInfomation";
     DeviceInfoMap infores = m_partedcore->getAllDeviceinfo();
     LVMInfo lvmInfo = m_partedcore->getAllLVMinfo();
     LUKSMap luksInfo = m_partedcore->getAllLUKSinfo();
@@ -112,24 +124,33 @@ void DiskManagerService::onGetAllDeviceInfomation()
 
 void DiskManagerService::setCurSelect(const PartitionInfo &info)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::setCurSelect";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for setCurSelect";
         return;
+    }
 
     m_partedcore->setCurSelect(info);
 }
 
 bool DiskManagerService::unmount()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::unmount";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for unmount";
         return false;
+    }
 
     return m_partedcore->unmount();
 }
 
 bool DiskManagerService::mount(const QString &mountpath)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::mount with mountpath:" << mountpath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for mount";
         return false;
+    }
 
     QString invokerUid = QString::number(connection().interface()->serviceUid(message().service()).value());
     return m_partedcore->mountAndWriteFstab(mountpath, invokerUid);
@@ -137,38 +158,51 @@ bool DiskManagerService::mount(const QString &mountpath)
 
 bool DiskManagerService::deCrypt(const LUKS_INFO &luks)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::deCrypt";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for deCrypt";
         return false;
+    }
 
     return m_partedcore->deCrypt(luks);
 }
 
 bool DiskManagerService::cryptMount(const LUKS_INFO &luks)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::cryptMount";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for cryptMount";
         return false;
+    }
 
     return m_partedcore->cryptMount(luks);
 }
 
 bool DiskManagerService::cryptUmount(const LUKS_INFO &luks)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::cryptUmount";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for cryptUmount";
         return false;
+    }
 
     return m_partedcore->cryptUmount(luks);
 }
 
 QStringList DiskManagerService::getallsupportfs()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::getallsupportfs";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for getallsupportfs";
         return QStringList();
+    }
 
     return m_partedcore->getallsupportfs();
 }
 
 bool DiskManagerService::format(const QString &fstype, const QString &name)
 {
+    qDebug() << "Entering DiskManagerService::format with fstype:" << fstype << "and name:" << name;
     if (!checkAuthorization()) {
         qWarning() << "Authorization failed for format operation";
         return false;
@@ -180,76 +214,106 @@ bool DiskManagerService::format(const QString &fstype, const QString &name)
 
 bool DiskManagerService::clear(const WipeAction &wipe)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::clear";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for clear";
         return false;
+    }
 
     return m_partedcore->clear(wipe);
 }
 
 bool DiskManagerService::resize(const PartitionInfo &info)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::resize";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for resize";
         return false;
+    }
 
     return m_partedcore->resize(info);
 }
 
 bool DiskManagerService::create(const PartitionVec &infovec)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::create";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for create";
         return false;
+    }
 
     return m_partedcore->create(infovec);
 }
 
 HardDiskInfo DiskManagerService::onGetDeviceHardInfo(const QString &devicepath)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onGetDeviceHardInfo for device:" << devicepath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onGetDeviceHardInfo";
         return HardDiskInfo();
+    }
 
     return m_partedcore->getDeviceHardInfo(devicepath);
 }
 
 QString DiskManagerService::onGetDeviceHardStatus(const QString &devicepath)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onGetDeviceHardStatus for device:" << devicepath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onGetDeviceHardStatus";
         return QString();
+    }
 
     return m_partedcore->getDeviceHardStatus(devicepath);
 }
 
 HardDiskStatusInfoList DiskManagerService::onGetDeviceHardStatusInfo(const QString &devicepath)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onGetDeviceHardStatusInfo for device:" << devicepath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onGetDeviceHardStatusInfo";
         return HardDiskStatusInfoList();
+    }
 
     return m_partedcore->getDeviceHardStatusInfo(devicepath);
 }
 bool DiskManagerService::onDeletePartition()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onDeletePartition";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onDeletePartition";
         return false;
+    }
 
     return m_partedcore->deletePartition();
 }
 bool DiskManagerService::onHidePartition()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onHidePartition";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onHidePartition";
         return false;
+    }
 
     return m_partedcore->hidePartition();
 }
 bool DiskManagerService::onShowPartition()
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onShowPartition";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onShowPartition";
         return false;
+    }
 
     return m_partedcore->showPartition();
 }
 bool DiskManagerService::onDetectionPartitionTableError(const QString &devicePath)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onDetectionPartitionTableError for device:" << devicePath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onDetectionPartitionTableError";
         return false;
+    }
 
     return m_partedcore->detectionPartitionTableError(devicePath);
 }
@@ -262,102 +326,141 @@ bool DiskManagerService::onCreatePartitionTable(const QString &devicePath, const
 }
 bool DiskManagerService::onCheckBadBlocksCount(const QString &devicePath, int blockStart, int blockEnd, int checkConut, int checkSize, int flag)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onCheckBadBlocksCount for device:" << devicePath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onCheckBadBlocksCount";
         return false;
+    }
 
     return m_partedcore->checkBadBlocks(devicePath, blockStart, blockEnd, checkConut, checkSize, flag);
 }
 bool DiskManagerService::onCheckBadBlocksTime(const QString &devicePath, int blockStart, int blockEnd, const QString &checkTime, int checkSize, int flag)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onCheckBadBlocksTime for device:" << devicePath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onCheckBadBlocksTime";
         return false;
+    }
 
     return m_partedcore->checkBadBlocks(devicePath, blockStart, blockEnd, checkTime, checkSize, flag);
 }
 bool DiskManagerService::onFixBadBlocks(const QString &devicePath, QStringList badBlocksList, int checkSize, int flag)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onFixBadBlocks for device:" << devicePath;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onFixBadBlocks";
         return false;
+    }
 
     return m_partedcore->fixBadBlocks(devicePath, badBlocksList, checkSize, flag);
 }
 
 bool DiskManagerService::onCreateVG(QString vgName, QList<PVData> devList, long long size)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onCreateVG for VG:" << vgName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onCreateVG";
         return false;
+    }
 
     return m_partedcore->createVG(vgName, devList, size);
 }
 
 bool DiskManagerService::onCreateLV(QString vgName, QList<LVAction> lvList)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onCreateLV for VG:" << vgName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onCreateLV";
         return false;
+    }
 
     return m_partedcore->createLV(vgName, lvList);
 }
 
 bool DiskManagerService::onDeleteVG(QStringList vglist)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onDeleteVG";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onDeleteVG";
         return false;
+    }
 
     return m_partedcore->deleteVG(vglist);
 }
 
 bool DiskManagerService::onDeleteLV(QStringList lvlist)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onDeleteLV";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onDeleteLV";
         return false;
+    }
 
     return m_partedcore->deleteLV(lvlist);
 }
 
 bool DiskManagerService::onResizeVG(QString vgName, QList<PVData> devList, long long size)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onResizeVG for VG:" << vgName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onResizeVG";
         return false;
+    }
 
     return m_partedcore->resizeVG(vgName, devList, size);
 }
 
 bool DiskManagerService::onResizeLV(LVAction lvAction)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onResizeLV for LV:" << lvAction.m_lvName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onResizeLV";
         return false;
+    }
 
     return m_partedcore->resizeLV(lvAction);
 }
 
 bool DiskManagerService::onMountLV(LVAction lvAction)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onMountLV for LV:" << lvAction.m_lvName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onMountLV";
         return false;
+    }
 
     return m_partedcore->mountLV(lvAction);
 }
 
 bool DiskManagerService::onUmountLV(LVAction lvAction)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onUmountLV for LV:" << lvAction.m_lvName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onUmountLV";
         return false;
+    }
 
     return m_partedcore->umountLV(lvAction);
 }
 
 bool DiskManagerService::onClearLV(LVAction lvAction)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onClearLV for LV:" << lvAction.m_lvName;
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onClearLV";
         return false;
+    }
 
     return m_partedcore->clearLV(lvAction);
 }
 
 bool DiskManagerService::onDeletePVList(QList<PVData> devList)
 {
-    if (!checkAuthorization())
+    qDebug() << "Entering DiskManagerService::onDeletePVList";
+    if (!checkAuthorization()) {
+        qDebug() << "Authorization failed for onDeletePVList";
         return false;
+    }
 
     return m_partedcore->deletePVList(devList);
 }

--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -27,6 +27,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
         qWarning() << "No SysFS BusID found in hwinfo info";
         return false;
     }
+    qDebug() << "SysFS BusID found, proceeding";
     setAttribute(mapInfo, "Model", m_model);
     setAttribute(mapInfo, "Vendor", m_vendor);
 
@@ -35,10 +36,12 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QRegularExpression re(".*\\((.*)\\).*");
     QRegularExpressionMatch match = re.match(m_interface);
     if (match.hasMatch()) {
+        qDebug() << "Interface match found";
         m_interface = match.captured(1);
 #else
     QRegExp re(".*\\((.*)\\).*");
     if (re.exactMatch(m_interface)) {
+        qDebug() << "Interface match found";
         m_interface = re.cap(1);
 #endif
         m_interface.replace("Controller", "");
@@ -55,6 +58,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     m_size.replace(QRegExp("\\(.*\\)"), "").replace(" ", "");
 #endif
     if (m_size.startsWith("0") || m_size == "") {
+        qDebug() << "Size is 0 or empty, returning false";
         return false;
     }
 
@@ -69,11 +73,14 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
 
 bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
 {
+    qDebug() << "Entering DeviceStorage::setKLUHwinfoInfo";
     // 龙芯机器中 hwinfo --disk会列出所有的分区信息
     // 存储设备不应包含分区，根据SysFS BusID 来确定是否是分区信息
     if (mapInfo.find("SysFS BusID") == mapInfo.end()) {
+        qDebug() << "No SysFS BusID found in KLU hwinfo, returning false";
         return false;
     }
+    qDebug() << "SysFS BusID found in KLU hwinfo, proceeding";
     setAttribute(mapInfo, "Model", m_model);
     setAttribute(mapInfo, "Vendor", m_vendor);
 
@@ -82,10 +89,12 @@ bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QRegularExpression re(".*\\((.*)\\).*");
     QRegularExpressionMatch match = re.match(m_interface);
     if (match.hasMatch()) {
+        qDebug() << "KLU Interface match found";
         m_interface = match.captured(1);
 #else
     QRegExp re(".*\\((.*)\\).*");
     if (re.exactMatch(m_interface)) {
+        qDebug() << "KLU Interface match found";
         m_interface = re.cap(1);
 #endif
         m_interface.replace("Controller", "");
@@ -102,6 +111,7 @@ bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
     m_size.replace(QRegExp("\\(.*\\)"), "").replace(" ", "");
 #endif
     if (m_size.startsWith("0") || m_size == "") {
+        qDebug() << "KLU size is 0 or empty, returning false";
         return false;
     }
 
@@ -113,10 +123,12 @@ bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
 
     // KLU里面的介质类型的处理方式比较特殊
     if (mapInfo["Driver"].contains("usb-storage")) {
+        qDebug() << "Driver contains usb-storage, setting media type to USB";
         m_mediaType = "USB";
     }
 
 //    loadOtherDeviceInfo(mapInfo);
+    qDebug() << "Exiting DeviceStorage::setKLUHwinfoInfo";
     return true;
 }
 
@@ -133,6 +145,7 @@ bool DeviceStorage::addInfoFromlshw(const QMap<QString, QString> &mapInfo)
     QString key = keys[1].trimmed();
     key.replace(".", ":");
     if (key != m_KeyToLshw) {
+        qDebug() << "lshw key does not match, returning false";
         return false;
     }
 
@@ -140,8 +153,11 @@ bool DeviceStorage::addInfoFromlshw(const QMap<QString, QString> &mapInfo)
     // 获取唯一key
     QStringList words = mapInfo["bus info"].split(":");
     if (words.size() == 2) {
+        qDebug() << "Setting KeyFromStorage";
         m_KeyFromStorage = words[0];
         m_KeyFromStorage.replace("@", "");
+    } else {
+        qDebug() << "Cannot set KeyFromStorage, invalid format for bus info";
     }
 
 
@@ -154,23 +170,30 @@ bool DeviceStorage::addInfoFromlshw(const QMap<QString, QString> &mapInfo)
 
 bool DeviceStorage::addInfoFromSmartctl(const QMap<QString, QString> &mapInfo)
 {
+    qDebug() << "Entering DeviceStorage::addInfoFromSmartctl";
     // 获取基本信息
     getInfoFromsmartctl(mapInfo);
+    qDebug() << "Exiting DeviceStorage::addInfoFromSmartctl";
     return true;
 }
 
 
 bool DeviceStorage::setMediaType(const QString &name, const QString &value)
 {
+    qDebug() << "Entering DeviceStorage::setMediaType for name:" << name << "value:" << value;
     if (!m_DeviceFile.contains(name)) {
+        qDebug() << "Device file does not contain name, returning false";
         return false;
     }
 
     if (QString("0") == value) {
+        qDebug() << "Setting media type to SSD";
         m_mediaType = "SSD";
     } else if (QString("1") == value) {
+        qDebug() << "Setting media type to HDD";
         m_mediaType = "HDD";
     } else {
+        qDebug() << "Setting media type to UnKnow";
         m_mediaType = "UnKnow";
     }
 
@@ -179,19 +202,25 @@ bool DeviceStorage::setMediaType(const QString &name, const QString &value)
 
 bool DeviceStorage::setKLUMediaType(const QString &name, const QString &value)
 {
+    qDebug() << "Entering DeviceStorage::setKLUMediaType for name:" << name << "value:" << value;
     if (!m_DeviceFile.contains(name)) {
+        qDebug() << "Device file does not contain name, returning false";
         return false;
     }
 
     if (m_mediaType == "USB") {
+        qDebug() << "Media type is already USB, returning true";
         return true;
     }
 
     if (QString("0") == value) {
+        qDebug() << "Setting media type to SSD for KLU";
         m_mediaType = "SSD";
     } else if (QString("1") == value) {
+        qDebug() << "Setting media type to HDD for KLU";
         m_mediaType = "HDD";
     } else {
+        qDebug() << "Setting media type to UnKnow for KLU";
         m_mediaType = "UnKnow";
     }
 
@@ -200,6 +229,7 @@ bool DeviceStorage::setKLUMediaType(const QString &name, const QString &value)
 
 void DeviceStorage::getInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qDebug() << "Entering DeviceStorage::getInfoFromLshw";
     setAttribute(mapInfo, "capabilities", m_capabilities);
     setAttribute(mapInfo, "version", m_version);
     setAttribute(mapInfo, "serial", m_serialNumber, false);
@@ -211,11 +241,13 @@ void DeviceStorage::getInfoFromLshw(const QMap<QString, QString> &mapInfo)
     QRegularExpression re(".*\\((.*)\\)$");
     QRegularExpressionMatch match = re.match(m_size);
     if (match.hasMatch()) {
+        qDebug() << "Size match found in lshw info";
         m_interface = match.captured(1);
     }
 #else
     QRegExp re(".*\\((.*)\\)$");
     if (re.exactMatch(m_size)) {
+        qDebug() << "Size match found in lshw info";
         m_size = re.cap(1);
     }
 #endif
@@ -231,6 +263,7 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
     QString sataVersion = mapInfo["SATA Version"];
     QStringList strList = sataVersion.split(",");
     if (strList.size() == 2) {
+        qDebug() << "SATA version found, setting speed";
         m_speed = strList[1].trimmed();
     }
 
@@ -239,12 +272,14 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
     // 通电时间
     m_powerOnHours = mapInfo["Power_On_Hours"];
     if (m_powerOnHours == "") {
+        qDebug() << "Power_On_Hours is empty, trying Power On Hours";
         m_powerOnHours = mapInfo["Power On Hours"];
     }
 
     // 通电次数
     m_powerCycleCount = mapInfo["Power_Cycle_Count"];
     if (m_powerCycleCount == "") {
+        qDebug() << "Power_Cycle_Count is empty, trying Power Cycles";
         m_powerCycleCount = mapInfo["Power Cycles"];
     }
 
@@ -289,6 +324,7 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
 
 void DeviceStorage::setAttribute(const QMap<QString, QString> &mapInfo, const QString &key, QString &variable, bool overwrite)
 {
+    // qDebug() << "Setting attribute for key:" << key;
     if (mapInfo.find(key) == mapInfo.end()) {
         qDebug() << "Key not found in map:" << key;
         return;
@@ -298,13 +334,16 @@ void DeviceStorage::setAttribute(const QMap<QString, QString> &mapInfo, const QS
         return;
     }
     if (overwrite) {
+        qDebug() << "Overwrite is true, setting variable to map value";
         variable = mapInfo[key].trimmed();
     } else {
         if (variable.isEmpty()) {
+            qDebug() << "Variable is empty, setting variable to map value";
             variable = mapInfo[key].trimmed();
         }
 
         if (variable.contains("Unknown", Qt::CaseInsensitive)) {
+            qDebug() << "Variable contains Unknown, setting variable to map value";
             variable = mapInfo[key].trimmed();
         }
     }
@@ -336,12 +375,14 @@ bool DeviceStorage::getDiskInfoFromHwinfo(const QString &devicePath)
 
 void DeviceStorage::getMapInfoFromHwinfo(const QString &info, QMap<QString, QString> &mapInfo, const QString &ch)
 {
+    qDebug() << "DeviceStorage::getMapInfoFromHwinfo BEGIN";
     QStringList infoList = info.split("\n");
 
     for (QStringList::iterator it = infoList.begin(); it != infoList.end(); ++it) {
         QStringList words = (*it).split(ch);
 
         if (words.size() != 2) {
+            qDebug() << "words.size() != 2, continue";
             continue;
         }
 
@@ -349,46 +390,56 @@ void DeviceStorage::getMapInfoFromHwinfo(const QString &info, QMap<QString, QStr
         QRegularExpression re(".*\"(.*)\".*");
         QRegularExpressionMatch match = re.match(words[1].trimmed());
         if (match.hasMatch()) {
+            qDebug() << "match.hasMatch() is true";
             QString key = words[0].trimmed();
             QString value = match.captured(1);
 #else
         QRegExp re(".*\"(.*)\".*");
         if (re.exactMatch(words[1].trimmed())) {
+            qDebug() << "re.exactMatch is true";
             QString key = words[0].trimmed();
             QString value = re.cap(1);
 #endif
 
             //这里是为了防止  "usb-storage", "sr"  -》 usb-storage", "sr
             if (key == "Driver") {
+                qDebug() << "key is Driver";
                 value.replace("\"", "");
             }
             mapInfo[key] += value;
 
         } else {
+            qDebug() << "match.hasMatch() is false";
             if (words[0].trimmed() == "Resolution") {
+                qDebug() << "words[0] is Resolution";
                 mapInfo[words[0].trimmed()] += words[1].trimmed();
             } else {
+                qDebug() << "words[0] is not Resolution";
                 mapInfo[words[0].trimmed()] = words[1].trimmed();
             }
         }
     }
+    qDebug() << "DeviceStorage::getMapInfoFromHwinfo END";
 }
 
 void DeviceStorage::getMapInfoFromInput(const QString &info, QMap<QString, QString> &mapInfo)
 {
-
+    qDebug() << "DeviceStorage::getMapInfoFromInput BEGIN";
     QStringList items = info.split("\n\n");
     foreach (const QString &item, items) {
         if (item.isEmpty()) {
+            qDebug() << "item is empty, continue";
             continue;
         }
 
         getMapInfoFromHwinfo(item, mapInfo);
      }
+    qDebug() << "DeviceStorage::getMapInfoFromInput END";
 }
 
 bool DeviceStorage::getDiskInfoFromLshw(const QString &devicePath)
 {
+    qDebug() << "DeviceStorage::getDiskInfoFromLshw BEGIN";
     QProcess proc;
     proc.start("sudo lshw -C disk");
     proc.waitForFinished(-1);
@@ -399,12 +450,14 @@ bool DeviceStorage::getDiskInfoFromLshw(const QString &devicePath)
     outPut.clear();
     for (int i =0;i<list.count();i++) {
         if(list.at(i).contains(devicePath)) {
+            qDebug() << "devicePath found in lshw output";
             outPut = list.at(i);
             break;
         }
     }
 
     if (outPut.isEmpty()) {
+        qDebug() << "devicePath not found in lshw output, return false";
         return false;
     }
 
@@ -414,51 +467,61 @@ bool DeviceStorage::getDiskInfoFromLshw(const QString &devicePath)
 
     addInfoFromlshw(mapInfo);
 
-
+    qDebug() << "DeviceStorage::getDiskInfoFromLshw END";
     return true;
 }
 
 void DeviceStorage::getMapInfoFromLshw(const QString &info, QMap<QString, QString> &mapInfo, const QString &ch)
 {
+    qDebug() << "DeviceStorage::getMapInfoFromLshw BEGIN";
     QStringList infoList = info.split("\n");
     for (QStringList::iterator it = infoList.begin(); it != infoList.end(); ++it) {
         QStringList words = (*it).split(ch);
         if (words.size() != 2) {
+            qDebug() << "words.size() != 2, continue";
             continue;
         }
         // && words[0].contains("configuration") == false && words[0].contains("resources") == false
         // 将configuration的内容进行拆分
         if (words[0].contains("configuration") == true) {
+            qDebug() << "words[0] contains configuration";
             QStringList keyValues = words[1].split(" ");
 
             for (QStringList::iterator it = keyValues.begin(); it != keyValues.end(); ++it) {
                 QStringList attr = (*it).split("=");
                 if (attr.size() != 2) {
+                    qDebug() << "attr.size() != 2, continue";
                     continue;
                 }
                 mapInfo.insert(attr[0].trimmed(), attr[1].trimmed());
             }
         } else if (words[0].contains("resources") == true) {
+            qDebug() << "words[0] contains resources";
             QStringList keyValues = words[1].split(" ");
 
             for (QStringList::iterator it = keyValues.begin(); it != keyValues.end(); ++it) {
                 QStringList attr = (*it).split(":");
                 if (attr.size() != 2) {
+                    qDebug() << "attr.size() != 2, continue";
                     continue;
                 }
                 if (mapInfo.find(attr[0].trimmed()) != mapInfo.end()) {
+                    qDebug() << "mapInfo contains attr[0].trimmed()";
                     mapInfo[attr[0].trimmed()] += QString("  ");
                 }
                 mapInfo[attr[0].trimmed()] += attr[1].trimmed();
             }
         } else {
+            qDebug() << "words[0] does not contain configuration or resources";
             mapInfo.insert(words[0].trimmed(), words[1].trimmed());
         }
     }
+    qDebug() << "DeviceStorage::getMapInfoFromLshw END";
 }
 
 bool DeviceStorage::getDiskInfoFromLsblk(const QString &devicePath)
 {
+    qDebug() << "DeviceStorage::getDiskInfoFromLsblk BEGIN";
     QString cmd = QString("lsblk -d -o name,rota %1").arg(devicePath);
     QProcess proc;
     proc.start(cmd);
@@ -470,16 +533,20 @@ bool DeviceStorage::getDiskInfoFromLsblk(const QString &devicePath)
     loadLsblkInfo(outPut, mapInfo);
 
     if (mapInfo.size() == 1) {
+        qDebug() << "mapInfo.size() is 1";
         setMediaType(mapInfo.firstKey(),mapInfo.value(mapInfo.firstKey()));
     } else {
+        qDebug() << "mapInfo.size() is not 1, return false";
         return false;
     }
 
+    qDebug() << "DeviceStorage::getDiskInfoFromLsblk END";
     return true;
 }
 
 void DeviceStorage::loadLsblkInfo(const QString &info, QMap<QString, QString> &mapInfo)
 {
+    qDebug() << "DeviceStorage::loadLsblkInfo BEGIN";
     QStringList lines = info.split("\n");
 
     foreach (QString line, lines) {
@@ -489,14 +556,17 @@ void DeviceStorage::loadLsblkInfo(const QString &info, QMap<QString, QString> &m
         QStringList words = line.replace(QRegExp("[\\s]+"), " ").split(" ");
 #endif
         if (words.size() != 2 || words[0] == "NAME") {
+            qDebug() << "words.size() != 2 or words[0] is NAME, continue";
             continue;
         }
         mapInfo.insert(words[0].trimmed(), words[1].trimmed());
     }
+    qDebug() << "DeviceStorage::loadLsblkInfo END";
 }
 
 bool DeviceStorage::getDiskInfoFromSmartCtl(const QString &devicePath)
 {
+    qDebug() << "DeviceStorage::getDiskInfoFromSmartCtl BEGIN";
     QString cmd = QString("smartctl --all %1").arg(devicePath);
     QProcess proc;
     proc.start(cmd);
@@ -504,6 +574,7 @@ bool DeviceStorage::getDiskInfoFromSmartCtl(const QString &devicePath)
     QString outPut  = proc.readAllStandardOutput();
 
     if (outPut.contains("Please specify device type with the -d option")) {
+        qDebug() << "need to specify device type";
         QString cmd = QString("smartctl --all -d sat %1").arg(devicePath);
         QProcess proc;
         proc.start(cmd);
@@ -517,11 +588,13 @@ bool DeviceStorage::getDiskInfoFromSmartCtl(const QString &devicePath)
 
     addInfoFromSmartctl(mapInfo);
 
+    qDebug() << "DeviceStorage::getDiskInfoFromSmartCtl END";
     return true;
 }
 
 void DeviceStorage::getDiskInfoModel(const QString &devicePath, QString &model)
 {
+    qDebug() << "DeviceStorage::getDiskInfoModel BEGIN";
     QProcess proc;
     QString cmd = QString("smartctl --all %1").arg(devicePath);
     proc.start(cmd);
@@ -529,6 +602,7 @@ void DeviceStorage::getDiskInfoModel(const QString &devicePath, QString &model)
     QString outPut = proc.readAllStandardOutput();
 
     if (outPut.contains("Please specify device type with the -d option")) {
+        qDebug() << "need to specify device type";
         cmd = QString("smartctl --all -d sat %1").arg(devicePath);
         proc.start(cmd);
         proc.waitForFinished(-1);
@@ -539,6 +613,7 @@ void DeviceStorage::getDiskInfoModel(const QString &devicePath, QString &model)
     for (int i = 0; i < infoList.size(); i++) {
         QString info = infoList[i];
         if(info.startsWith("Device Model:") || info.startsWith("Product:") || info.startsWith("Model Number:")){
+            qDebug() << "found model in smartctl output";
             model = info.split(":").last().trimmed();
             return;
         }
@@ -552,9 +627,11 @@ void DeviceStorage::getDiskInfoModel(const QString &devicePath, QString &model)
     infoList = outPut.split("*-disk\n");
     for (int i =0; i < infoList.size(); i++) {
         if(infoList[i].contains(devicePath)) {
+            qDebug() << "found devicePath in lshw output";
             QStringList tempList = infoList[i].split("\n");
             for (int j = 0; j < tempList.size(); j++) {
                 if(tempList[j].contains("product:")){
+                    qDebug() << "found model in lshw output";
                     model = tempList[j].split(":").last().trimmed();
                     return;
                 }
@@ -564,12 +641,14 @@ void DeviceStorage::getDiskInfoModel(const QString &devicePath, QString &model)
     }
 
     // 若未获取到型号名，返回未知
+    qDebug() << "model not found, set to UnKnow";
     model = "UnKnow";
     return;
 }
 
 QString DeviceStorage::getDiskInfoMediaType(const QString &devicePath)
 {
+    qDebug() << "DeviceStorage::getDiskInfoMediaType BEGIN";
     QStringList deviceList = devicePath.split("/");
     QString device = deviceList[deviceList.size()-1];
     QString value;
@@ -581,29 +660,36 @@ QString DeviceStorage::getDiskInfoMediaType(const QString &devicePath)
     value = outPut;
 
     if ("1" == value) {
+        qDebug() << "value is 1";
         cmd = QString("smartctl -i %1").arg(devicePath);
         proc.start(cmd);
         proc.waitForFinished(-1);
         outPut = proc.readAllStandardOutput();
         if (outPut.contains("Solid State Device")) {
+            qDebug() << "is Solid State Device";
             value = "0";
         } else if (outPut.contains("Please specify device type with the -d option")) {
+            qDebug() << "need to specify device type";
             //FIXME: Hard type scsi for USB disk
             cmd = QString("smartctl -i -d scsi %1").arg(devicePath);
             proc.start(cmd);
             proc.waitForFinished(-1);
             outPut = proc.readAllStandardOutput();
             if (!outPut.contains("Rotation Rate:")) {
+                qDebug() << "not contains Rotation Rate";
                 value = "0";
             }
         }
 
     }
     if (QString("0") == value) {
+        qDebug() << "return SSD";
         return  "SSD";
     } else if (QString("1") == value) {
+        qDebug() << "return HDD";
         return "HDD";
     } else {
+        qDebug() << "return UnKnow";
         return "UnKnow";
     }
 }
@@ -613,8 +699,10 @@ static bool isPGUX()
     static int isPGUX = -1;
     QString output, err;
 
-    if (isPGUX != -1)
+    if (isPGUX != -1) {
+        qDebug() << "isPGUX is not -1, return isPGUX";
         return 1 == isPGUX;
+    }
 
     Utils::executeCmdWithArtList("dmidecode", QStringList() << "-t" << "11", output, err);
     QRegularExpression re("String 4: (.+?)\\s");
@@ -626,19 +714,25 @@ static bool isPGUX()
 
 void DeviceStorage::getDiskInfoInterface(const QString &devicePath, QString &interface, QString &model)
 {
+    qDebug() << "DeviceStorage::getDiskInfoInterface BEGIN";
     QString bootDevicePath("/proc/bootdevice/product_name");
     QFile file(bootDevicePath);
 
     if (file.open(QIODevice::ReadOnly)) {
+        qDebug() << "open /proc/bootdevice/product_name success";
         if (model == file.readLine().simplified()) {
+            qDebug() << "model is boot device";
             QString spec_version = Utils::readContent("/sys/block/sdd/device/spec_version").trimmed();
-            if (!spec_version.isEmpty())
+            if (!spec_version.isEmpty()) {
+                qDebug() << "spec_version is not empty";
                 interface = (spec_version == "300") ? "UFS 3.0" : "UFS 3.1";
+            }
         }
         file.close();
     }
 
     if (interface.isEmpty()) {
+        qDebug() << "interface is empty";
         QString cmd = QString("hwinfo --disk --only %1").arg(devicePath);
         QProcess proc;
         proc.start(cmd);
@@ -647,27 +741,36 @@ void DeviceStorage::getDiskInfoInterface(const QString &devicePath, QString &int
         QStringList outPutList = outPut.split("(");
         interface = outPutList[outPutList.size() - 1].split(" ")[0];
     }
+    qDebug() << "DeviceStorage::getDiskInfoInterface END";
     return;
 }
 
 void DeviceStorage::updateForHWDevice(const QString &devicePath)
 {
-    if (m_model != Utils::readContent("/proc/bootdevice/product_name").trimmed())
+    qDebug() << "DeviceStorage::updateForHWDevice BEGIN";
+    if (m_model != Utils::readContent("/proc/bootdevice/product_name").trimmed()) {
+        qDebug() << "m_model is not boot device, return";
         return;
+    }
 
     // m_firmwareVersion
     if (m_firmwareVersion.isEmpty()) {
-        if (isPGUX())
+        qDebug() << "m_firmwareVersion is empty";
+        if (isPGUX()) {
+            qDebug() << "is PGUX";
             m_firmwareVersion = Utils::readContent("/proc/bootdevice/rev").trimmed();
+        }
     }
 
     // hide model and vendor
     m_model = "";
     m_vendor = "";
+    qDebug() << "DeviceStorage::updateForHWDevice END";
 }
 
 void DeviceStorage::getMapInfoFromSmartctl(QMap<QString, QString> &mapInfo, const QString &info, const QString &ch)
 {
+    qDebug() << "DeviceStorage::getMapInfoFromSmartctl BEGIN";
     QString indexName;
     int startIndex = 0;
 
@@ -694,18 +797,22 @@ void DeviceStorage::getMapInfoFromSmartctl(QMap<QString, QString> &mapInfo, cons
         if (index > 0 && reg.exactMatch(line) == false && false == line.contains("Error") && false == line.contains("hh:mm:SS")) {
 #endif
             if (line.indexOf("(") < index && line.indexOf(")") > index) {
+                qDebug() << "bracket contains ch, continue";
                 continue;
             }
 
             if (line.indexOf("[") < index && line.indexOf("]") > index) {
+                qDebug() << "square bracket contains ch, continue";
                 continue;
             }
 
             indexName = line.mid(0, index).trimmed().remove(" is");
             if (mapInfo.contains(indexName)) {
+                qDebug() << "mapInfo contains indexName";
                 mapInfo[indexName] += ", ";
                 mapInfo[indexName] += line.mid(index + 1).trimmed();
             } else {
+                qDebug() << "mapInfo not contains indexName";
                 mapInfo[indexName] = line.mid(index + 1).trimmed();
             }
             continue;
@@ -713,9 +820,11 @@ void DeviceStorage::getMapInfoFromSmartctl(QMap<QString, QString> &mapInfo, cons
 
         if (indexName.isEmpty() == false && (line.startsWith("\t\t") || line.startsWith("    ")) && line.contains(":") == false) {
             if (mapInfo.contains(indexName)) {
+                qDebug() << "mapInfo contains indexName";
                 mapInfo[indexName] += ", ";
                 mapInfo[indexName] += line.trimmed();
             } else {
+                qDebug() << "mapInfo not contains indexName";
                 mapInfo[indexName] = line.trimmed();
             }
 
@@ -727,12 +836,14 @@ void DeviceStorage::getMapInfoFromSmartctl(QMap<QString, QString> &mapInfo, cons
         QRegularExpression rx("^[ ]*[0-9]+[ ]+([\\w-_]+)[ ]+0x[0-9a-fA-F-]+[ ]+[0-9]+[ ]+[0-9]+[ ]+[0-9]+[ ]+[\\w-]+[ ]+[\\w-]+[ ]+[\\w-]+[ ]+([0-9\\/w-]+[ ]*[ 0-9\\/w-()]*)$");
         QRegularExpressionMatch matchR = rx.match(line);
         if (matchR.hasMatch()) {
+            qDebug() << "matchR.hasMatch() is true";
             mapInfo[matchR.captured(1)] = matchR.captured(2);
             continue;
         }
 #else
         QRegExp rx("^[ ]*[0-9]+[ ]+([\\w-_]+)[ ]+0x[0-9a-fA-F-]+[ ]+[0-9]+[ ]+[0-9]+[ ]+[0-9]+[ ]+[\\w-]+[ ]+[\\w-]+[ ]+[\\w-]+[ ]+([0-9\\/w-]+[ ]*[ 0-9\\/w-()]*)$");
         if (rx.indexIn(line) > -1) {
+            qDebug() << "rx.indexIn(line) > -1";
             mapInfo[rx.cap(1)] = rx.cap(2);
             continue;
         }
@@ -741,102 +852,126 @@ void DeviceStorage::getMapInfoFromSmartctl(QMap<QString, QString> &mapInfo, cons
         QStringList strList;
 
         if (line.endsWith(")")) {
+            qDebug() << "line endsWith )";
             int leftBracket = line.indexOf("(");
             if (leftBracket > 0) {
+                qDebug() << "leftBracket > 0";
                 QString str = line.left(leftBracket).trimmed();
                 strList = str.trimmed().split(" ");
                 if (strList.size() > 2) {
+                    qDebug() << "strList.size() > 2";
                     strList.last() += line.mid(leftBracket);
                 }
             }
         } else if (strList.size() == 0) {
+            qDebug() << "strList.size() is 0";
             strList = line.trimmed().split(" ");
         }
 
         if (strList.size() < 5) {
+            qDebug() << "strList.size() < 5, continue";
             continue;
         }
 
         if (line.contains("Power_On_Hours")) {
+            qDebug() << "line contains Power_On_Hours";
             mapInfo["Power_On_Hours"] = strList.last();
             continue;
         }
 
         if (line.contains("Power_Cycle_Count")) {
+            qDebug() << "line contains Power_Cycle_Count";
             mapInfo["Power_Cycle_Count"] = strList.last();
             continue;
         }
 
         if (line.contains("Raw_Read_Error_Rate")) {
+            qDebug() << "line contains Raw_Read_Error_Rate";
             mapInfo["Raw_Read_Error_Rate"] = strList.last();
             continue;
         }
 
         if (line.contains("Spin_Up_Time")) {
+            qDebug() << "line contains Spin_Up_Time";
             mapInfo["Spin_Up_Time"] = strList.last();
             continue;
         }
 
         if (line.contains("Start_Stop_Count")) {
+            qDebug() << "line contains Start_Stop_Count";
             mapInfo["Start_Stop_Count"] = strList.last();
             continue;
         }
 
         if (line.contains("Reallocated_Sector_Ct")) {
+            qDebug() << "line contains Reallocated_Sector_Ct";
             mapInfo["Reallocated_Sector_Ct"] = strList.last();
             continue;
         }
 
         if (line.contains("Seek_Error_Rate")) {
+            qDebug() << "line contains Seek_Error_Rate";
             mapInfo["Seek_Error_Rate"] = strList.last();
             continue;
         }
 
         if (line.contains("Spin_Retry_Count")) {
+            qDebug() << "line contains Spin_Retry_Count";
             mapInfo["Spin_Retry_Count"] = strList.last();
             continue;
         }
         if (line.contains("Calibration_Retry_Count")) {
+            qDebug() << "line contains Calibration_Retry_Count";
             mapInfo["Calibration_Retry_Count"] = strList.last();
             continue;
         }
         if (line.contains("G-Sense_Error_Rate")) {
+            qDebug() << "line contains G-Sense_Error_Rate";
             mapInfo["G-Sense_Error_Rate"] = strList.last();
             continue;
         }
         if (line.contains("Power-Off_Retract_Count")) {
+            qDebug() << "line contains Power-Off_Retract_Count";
             mapInfo["Power-Off_Retract_Count"] = strList.last();
             continue;
         }
         if (line.contains("Load_Cycle_Count")) {
+            qDebug() << "line contains Load_Cycle_Count";
             mapInfo["Load_Cycle_Count"] = strList.last();
             continue;
         }
         if (line.contains("Temperature_Celsius")) {
+            qDebug() << "line contains Temperature_Celsius";
             mapInfo["Temperature_Celsius"] = strList.last();
             continue;
         }
         if (line.contains("Reallocated_Event_Count")) {
+            qDebug() << "line contains Reallocated_Event_Count";
             mapInfo["Reallocated_Event_Count"] = strList.last();
             continue;
         }
         if (line.contains("Current_Pending_Sector")) {
+            qDebug() << "line contains Current_Pending_Sector";
             mapInfo["Current_Pending_Sector"] = strList.last();
             continue;
         }
         if (line.contains("Offline_Uncorrectable")) {
+            qDebug() << "line contains Offline_Uncorrectable";
             mapInfo["Offline_Uncorrectable"] = strList.last();
             continue;
         }
         if (line.contains("UDMA_CRC_Error_Count")) {
+            qDebug() << "line contains UDMA_CRC_Error_Count";
             mapInfo["UDMA_CRC_Error_Count"] = strList.last();
             continue;
         }
         if (line.contains("Multi_Zone_Error_Rate")) {
+            qDebug() << "line contains Multi_Zone_Error_Rate";
             mapInfo["Multi_Zone_Error_Rate"] = strList.last();
             continue;
         }
     }
+    qDebug() << "DeviceStorage::getMapInfoFromSmartctl END";
 }
 
 }

--- a/service/diskoperation/device.cpp
+++ b/service/diskoperation/device.cpp
@@ -48,6 +48,7 @@ Device::Device()
     m_highestBusy = 0;
     m_readonly = false;
     m_maxPartitionNameLength = 0;
+    qDebug() << "Device object initialized";
 }
 
 void Device::enablePartitionNaming(int length)
@@ -63,6 +64,7 @@ void Device::enablePartitionNaming(int length)
 
 bool Device::partitionNamingSupported() const
 {
+    qDebug() << "Checking if partition naming is supported. Max length:" << m_maxPartitionNameLength;
     return m_maxPartitionNameLength > 0;
 }
 
@@ -73,6 +75,7 @@ bool Device::partitionNamingSupported() const
 
 DeviceInfo Device::getDeviceInfo()
 {
+    qDebug() << "Entering Device::getDeviceInfo";
     DeviceInfo info;
     info.m_length = m_length;
     info.m_heads = m_heads;

--- a/service/diskoperation/filesystems/exfat.cpp
+++ b/service/diskoperation/filesystems/exfat.cpp
@@ -18,16 +18,22 @@ FS ExFat::getFilesystemSupport()
     fs.move = FS::GPARTED;
     fs.online_read = FS::GPARTED;
 
-    if (!Utils::findProgramInPath("dump.exfat").isEmpty())
+    if (!Utils::findProgramInPath("dump.exfat").isEmpty()) {
+        qDebug() << "dump.exfat found, enabling read support";
         fs.read = FS::EXTERNAL;
+    }
 
     QString output, error;
     if (!Utils::findProgramInPath("mkfs.exfat").isEmpty()) {
-        if (Utils::executCmd("mkfs.exfat -V", output, error) == 0)
+        qDebug() << "mkfs.exfat found, checking version for create support";
+        if (Utils::executCmd("mkfs.exfat -V", output, error) == 0) {
+            qDebug() << "mkfs.exfat version check successful, enabling create support";
             fs.create = FS::EXTERNAL;
+        }
     }
 
     if (!Utils::findProgramInPath("tune.exfat").isEmpty()) {
+        qDebug() << "tune.exfat found, enabling label and uuid support";
         fs.read_label = FS::EXTERNAL;
         fs.write_label = FS::EXTERNAL;
 
@@ -35,15 +41,19 @@ FS ExFat::getFilesystemSupport()
         // 1.1.0.  Check the help text for the feature before enabling.
         Utils::executCmd("tune.exfat", output, error);
         if (error.indexOf("Set volume serial") < error.length()) {
+            qDebug() << "tune.exfat supports setting volume serial, enabling uuid read/write";
             fs.read_uuid = FS::EXTERNAL;
             fs.write_uuid = FS::EXTERNAL;
         }
     }
 
     if (!Utils::findProgramInPath("fsck.exfat").isEmpty()) {
+        qDebug() << "fsck.exfat found, checking version for check support";
         Utils::executCmd("fsck.exfat -V", output, error);
-        if (output.contains("exfatprogs version"))
+        if (output.contains("exfatprogs version")) {
+            qDebug() << "fsck.exfat from exfatprogs found, enabling check support";
             fs.check = FS::EXTERNAL;
+        }
     }
     fs.grow = FS::NONE;
     fs.shrink = FS::NONE;
@@ -59,6 +69,7 @@ void ExFat::setUsedSectors(DiskManager::Partition &partition)
     // dump.exfat returns non-zero status for both success and failure.  Instead use
     // non-empty stderr to identify failure.
     if (!error.isEmpty() || errCode != 0) {
+        qDebug() << "dump.exfat failed with error:" << error << "and exit code:" << errCode;
         return;
     }
 
@@ -78,30 +89,39 @@ void ExFat::setUsedSectors(DiskManager::Partition &partition)
     // FS size in [FS] sectors
     long long volume_length = -1;
     int index = output.indexOf("Volume Length(sectors):");
-    if (index < output.length())
+    if (index < output.length()) {
+        qDebug() << "Found Volume Length";
         sscanf(output.mid(index).toStdString().c_str(), "Volume Length(sectors): %lld", &volume_length);
+    }
 
     // FS sector size = 2^(bytes_per_sector_shift)
     long long bytes_per_sector_shift = -1;
     index = output.indexOf("Sector Size Bits:");
-    if (index < output.length())
+    if (index < output.length()) {
+        qDebug() << "Found Sector Size Bits";
         sscanf(output.mid(index).toStdString().c_str(), "Sector Size Bits: %lld", &bytes_per_sector_shift);
+    }
 
     // Cluster size = sector_size * 2^(sectors_per_cluster_shift)
     long long sectors_per_cluster_shift = -1;
     index = output.indexOf("Sector per Cluster bits:");
-    if (index < output.length())
+    if (index < output.length()) {
+        qDebug() << "Found Sector per Cluster bits";
         sscanf(output.mid(index).toStdString().c_str(), "Sector per Cluster bits: %lld",
                &sectors_per_cluster_shift);
+    }
 
     // Free clusters
     long long free_clusters = -1;
     index = output.indexOf("Free Clusters:");
-    if (index < output.length())
+    if (index < output.length()) {
+        qDebug() << "Found Free Clusters";
         sscanf(output.mid(index).toStdString().c_str(), "Free Clusters: %lld", &free_clusters);
+    }
 
     if (volume_length > -1 && bytes_per_sector_shift > -1 &&
         sectors_per_cluster_shift > -1 && free_clusters > -1) {
+        qDebug() << "All required values found, calculating and setting sector usage";
         Byte_Value sector_size = 1 << bytes_per_sector_shift;
         Byte_Value cluster_size = sector_size * (1 << sectors_per_cluster_shift);
         Sector fs_free = free_clusters * cluster_size / partition.m_sectorSize;
@@ -117,6 +137,7 @@ void ExFat::readLabel(DiskManager::Partition &partition)
     QString output, error;
     auto errCode = Utils::executCmd(QString("tune.exfat -l %1").arg(partition.getPath()), output, error);
     if (errCode != 0) {
+        qDebug() << "tune.exfat -l failed with exit code:" << errCode;
         return;
     }
 
@@ -129,10 +150,12 @@ bool ExFat::writeLabel(const DiskManager::Partition &partition)
             << "new label:" << partition.getFileSystemLabel();
     QString cmd, output, error;
     if (!partition.getFileSystemLabel().isEmpty() && partition.getFileSystemLabel() != " ") {
+        qDebug() << "Label is not empty, writing it";
         cmd = QString("tune.exfat -L %1 %2").arg(partition.getFileSystemLabel()).arg(partition.getPath());
         auto errCode = Utils::executCmd(cmd, output, error);
         return errCode == 0;
     }
+    qDebug() << "Label is empty, doing nothing";
     return true;
 }
 
@@ -142,6 +165,7 @@ void ExFat::readUuid(DiskManager::Partition &partition)
     QString output, error;
     auto errCode = Utils::executCmd(QString("tune.exfat -i %1").arg(partition.getPath()), output, error);
     if (errCode != 0) {
+        qDebug() << "tune.exfat -i failed with exit code:" << errCode;
         return;
     }
     partition.m_uuid = serial2BlkidUuid(
@@ -164,8 +188,10 @@ bool ExFat::create(const DiskManager::Partition &new_partition)
             << "with label:" << new_partition.getFileSystemLabel();
     QString cmd, output, error;
     if (new_partition.getFileSystemLabel().isEmpty() || new_partition.getFileSystemLabel() == " ") {
+        qDebug() << "Label is empty, creating without label";
         cmd = QString("mkfs.exfat %1").arg(new_partition.getPath());
     } else {
+        qDebug() << "Label is not empty, creating with label";
         cmd = QString("mkfs.exfat -n %1 %2").arg(new_partition.getFileSystemLabel()).arg(new_partition.getPath());
     }
     auto errCode = Utils::executCmd(cmd, output, error);
@@ -174,16 +200,19 @@ bool ExFat::create(const DiskManager::Partition &new_partition)
 
 bool ExFat::resize(const DiskManager::Partition &partitionNew, bool fillPartition)
 {
+    qDebug() << "Entering ExFat::resize for partition:" << partitionNew.getPath();
     return FileSystem::resize(partitionNew, fillPartition);
 }
 
 bool DiskManager::ExFat::resize(const QString &path, const QString &size, bool fillPartition)
 {
+    qDebug() << "Entering ExFat::resize for path:" << path;
     return FileSystem::resize(path, size, fillPartition);
 }
 
 bool DiskManager::ExFat::checkRepair(const DiskManager::Partition &partition)
 {
+    qDebug() << "Entering ExFat::checkRepair for partition:" << partition.getPath();
     QString path = partition.getPath();
     return checkRepair(path);
 }
@@ -198,6 +227,7 @@ bool DiskManager::ExFat::checkRepair(const QString &devpath)
 
 FS_Limits DiskManager::ExFat::getFilesystemLimits(const DiskManager::Partition &partition)
 {
+    qDebug() << "Entering ExFat::getFilesystemLimits";
     m_fsLimits.min_size = -1;
     m_fsLimits.max_size = -1;
     return m_fsLimits;
@@ -205,9 +235,12 @@ FS_Limits DiskManager::ExFat::getFilesystemLimits(const DiskManager::Partition &
 
 QString DiskManager::ExFat::serial2BlkidUuid(QString serial)
 {
+    qDebug() << "Entering ExFat::serial2BlkidUuid for serial:" << serial;
     QString verifiedSerial = Utils::regexpLabel(serial, "^(0x[[:xdigit:]][[:xdigit:]]*)$");
-    if (verifiedSerial.isEmpty())
+    if (verifiedSerial.isEmpty()) {
+        qDebug() << "Serial is not valid";
         return verifiedSerial;
+    }
 
     QString canonicalUuid = verifiedSerial.mid(2, 4).toUpper() + "-" +
                             verifiedSerial.mid(6, 4).toUpper();
@@ -216,6 +249,7 @@ QString DiskManager::ExFat::serial2BlkidUuid(QString serial)
 
 QString DiskManager::ExFat::randomSerial()
 {
+    qDebug() << "Generating random serial number for exFAT";
     return "0x" + QUuid::createUuid().toString().mid(0, 8);
 }
 

--- a/service/diskoperation/filesystems/fat16.cpp
+++ b/service/diskoperation/filesystems/fat16.cpp
@@ -25,28 +25,35 @@ FS FAT16::getFilesystemSupport()
     fs.busy = FS::GPARTED ;
 
     if (!Utils::findProgramInPath("mdir").isEmpty()) {
+        qDebug() << "mdir found, enabling uuid and read support";
 		fs.read_uuid = FS::EXTERNAL;
-        if (!Utils::findProgramInPath("minfo").isEmpty())
+        if (!Utils::findProgramInPath("minfo").isEmpty()) {
+            qDebug() << "minfo found, enabling read support";
 			fs.read = FS::EXTERNAL;
+        }
 	}
 
 	//find out if we can create fat file systems
     if (!Utils::findProgramInPath( "mkfs.fat" ).isEmpty()) {
+        qDebug() << "mkfs.fat found, enabling create support";
 		fs.create = FS::EXTERNAL;
 		fs.create_with_label = FS::EXTERNAL;
 	}
 
     if (!Utils::findProgramInPath( "fsck.fat" ).isEmpty()) {
+        qDebug() << "fsck.fat found, enabling check support";
 		fs.check = FS::EXTERNAL;
 	}
 
     if (!Utils::findProgramInPath( "mlabel" ).isEmpty()) {
+        qDebug() << "mlabel found, enabling label and uuid write support";
         fs.read_label = FS::EXTERNAL;
         fs.write_label = FS::EXTERNAL;
         fs.write_uuid = FS::EXTERNAL;
 	}
 
 #ifdef HAVE_LIBPARTED_FS_RESIZE
+    qDebug() << "libparted fs resize support found, enabling grow and shrink";
 	//resizing of start and endpoint are provided by libparted
 	fs.grow = FS::LIBPARTED;
 	fs.shrink = FS::LIBPARTED;
@@ -56,9 +63,11 @@ FS FAT16::getFilesystemSupport()
     fs.online_read = FS::GPARTED;
 
     if (fs.fstype == FS_FAT16) {
+        qDebug() << "Setting filesystem limits for FAT16";
         m_fsLimits.min_size = 16 * MEBIBYTE;
         m_fsLimits.max_size = (4096 - 1) * MEBIBYTE;  // Maximum seems to be just less than 4096 MiB.
     } else {
+        qDebug() << "Setting filesystem limits for FAT32";
         //FS_FAT32
         m_fsLimits.min_size = 33 * MEBIBYTE;  // Smaller file systems will cause Windows' scandisk to fail.
 
@@ -95,8 +104,10 @@ void FAT16::setUsedSectors( Partition & partition )
     QString spacedNumberStr = Utils::regexpLabel(output, "^ *([0-9 ]*) bytes free$").remove(QRegExp("\\s")).trimmed();
 #endif
 
-    if (spacedNumberStr.size() > 0)
+    if (spacedNumberStr.size() > 0) {
+        qDebug() << "Found free bytes string:" << spacedNumberStr;
         m_numOfFreeOrUsedBlocks = atoll(spacedNumberStr.toStdString().c_str());
+    }
     }
 	// Use minfo's reporting of the BPB (BIOS Parameter Block) to get the file system
 	// size and FS block (cluster) size.
@@ -110,6 +121,7 @@ void FAT16::setUsedSectors( Partition & partition )
         strmatch = "sector size:";
         int index = output.indexOf(strmatch);
         if (index >= 0 && index < output.length()) {
+            qDebug() << "Found sector size";
             list = Utils::regexpLabel(output, QString("(?<=sector size:).*(?=\n)")).trimmed().split(" ");
             logicalSectorSize = list.at(0).toLong();
         }
@@ -118,6 +130,7 @@ void FAT16::setUsedSectors( Partition & partition )
         strmatch = "cluster size:";
         index = output.indexOf(strmatch);
         if (index >= 0 && index < output.length()) {
+            qDebug() << "Found cluster size";
             list = Utils::regexpLabel(output, QString("(?<=cluster size:).*(?=\n)")).trimmed().split(" ");
             clusterSize = list.at(0).toLong();
         }
@@ -126,6 +139,7 @@ void FAT16::setUsedSectors( Partition & partition )
         strmatch = "small size:";
         index = output.indexOf(strmatch);
         if (index >= 0 && index < output.length()) {
+            qDebug() << "Found small size";
             list = Utils::regexpLabel(output, QString("(?<=small size:).*(?=\n)")).trimmed().split(" ");
             smallSize = list.at(0).toLong();
         }
@@ -134,14 +148,17 @@ void FAT16::setUsedSectors( Partition & partition )
         strmatch = "big size:";
         index = output.indexOf(strmatch);
         if (index >= 0 && index < output.length()) {
+            qDebug() << "Found big size";
             list = Utils::regexpLabel(output, QString("(?<=big size:).*(?=\n)")).trimmed().split(" ");
             bigSize = list.at(0).toLong();
         }
 
         if (bigSize <= 0 && smallSize <= 0) {
+            qDebug() << "Big size and small size are 0, parsing mformat command line";
             list = output.split("\n");
             for (int i = 0; i < list.size(); i++) {
                 if (list.at(i).contains("mformat command line: mformat -T ")) {
+                    qDebug() << "Found mformat command line";
                     QStringList slist = list.at(i).split("-T");
                     list.clear();
                     list = slist.at(1).split("-h");
@@ -155,14 +172,18 @@ void FAT16::setUsedSectors( Partition & partition )
 	// FS size in logical sectors
 	long long logical_sectors = -1;
     if (smallSize > 0) {
+        qDebug() << "Using small size for logical sectors";
         logical_sectors = smallSize;
     } else if (bigSize > 0) {
+        qDebug() << "Using big size for logical sectors";
         logical_sectors = bigSize;
     } else {
+        qDebug() << "Using total number of blocks for logical sectors";
         logical_sectors = m_totalNumOfBlock;
     }
 
     if (m_numOfFreeOrUsedBlocks > -1 && logicalSectorSize > -1 && clusterSize > -1 && logical_sectors > -1) {
+        qDebug() << "All values found, calculating and setting sector usage";
         Sector fsfree = m_numOfFreeOrUsedBlocks / partition.m_sectorSize;
         Sector fsSize = logical_sectors * logicalSectorSize / partition.m_sectorSize;
 
@@ -181,12 +202,15 @@ void FAT16::readLabel( Partition & partition )
     QString partitionPath = partition.getPath().remove("/dev/");
     if (!Utils::executCmd(QString("ls -l /dev/disk/by-label"), output, error)) {
         if(output.indexOf(partitionPath)) {
+            qDebug() << "Found partition path in ls output";
             QStringList list = output.split("\n");
             for (int i = 0; i < list.size(); i++) {
                 if(list.at(i).indexOf(partitionPath) != -1) {
+                    // qDebug() << "Found line with partition path:" << list.at(i);
                     QStringList slist = list.at(i).split(" ");
                     for (int j = 0; j < slist.size(); j++) {
                         if(slist.at(j) == "->" && j != 0) {
+                            qDebug() << "Found label:" << slist.at(j-1);
                             filesystemLabel = slist.at(j-1);
                             break;
                         }
@@ -196,6 +220,7 @@ void FAT16::readLabel( Partition & partition )
         }
     }
     if (!filesystemLabel.isEmpty()) {
+        qDebug() << "Setting filesystem label:" << filesystemLabel;
         partition.setFilesystemLabel(filesystemLabel);
     }
 
@@ -206,10 +231,13 @@ bool FAT16::writeLabel(const Partition & partition)
     qDebug() << "Writing label for FAT partition:" << partition.getPath()
             << "new label:" << partition.getFileSystemLabel();
     QString output, error, cmd;
-    if (partition.getFileSystemLabel().isEmpty() || partition.getFileSystemLabel() == " ")
+    if (partition.getFileSystemLabel().isEmpty() || partition.getFileSystemLabel() == " ") {
+        qDebug() << "Label is empty, clearing it";
         cmd = QString("mlabel -c :: -i %1").arg(partition.getPath());
-	else
+	} else {
+        qDebug() << "Label is not empty, setting it";
         cmd = QString("mlabel :: %1 -i %2").arg(partition.getFileSystemLabel()).arg(partition.getPath());
+    }
 
 //    qDebug() << __FUNCTION__ << cmd;
     int exitcode = Utils::executCmd(cmd, output, error);
@@ -226,9 +254,12 @@ void FAT16::readUuid( Partition & partition )
     QString cmd = QString("mdir -f :: -i %1").arg(partition.getPath());
 
     if (!Utils::executCmd( cmd, output, error)) {
+        qDebug() << "mdir successful, parsing volume serial number";
         partition.m_uuid = Utils::regexpLabel(output, "Volume Serial Number is[[:blank:]]([^[:space:]]+)");
-        if (partition .m_uuid == "0000-0000")
+        if (partition .m_uuid == "0000-0000") {
+            qDebug() << "Volume serial number is 0000-0000, clearing it";
             partition .m_uuid .clear() ;
+        }
 	}
 //    qDebug() << __FUNCTION__ << output << error;
 }
@@ -248,17 +279,22 @@ bool FAT16::create(const Partition & new_partition)
     QString output, error, cmd;
     QString fat_size = (specificType == FS_FAT16 ? "16" : "32");
     int exitcode = -1;
-    if(new_partition.getFileSystemLabel().isEmpty() || new_partition.getFileSystemLabel() == " ") {
-        exitcode = Utils::executCmd(QString("mkfs.fat -F %1 -v -I %2").arg(fat_size).arg(new_partition.getPath()), output, error);
+    if (new_partition.getFileSystemLabel().isEmpty() || new_partition.getFileSystemLabel() == " ") {
+        qDebug() << "Label is empty, creating without label";
+        cmd = QString("mkfs.fat -F %1 -v -I %2").arg(fat_size).arg(new_partition.getPath());
     } else {
+        qDebug() << "Label is not empty, creating with label";
         cmd = QString("mkfs.fat -F %1 -v -I -n %2 %3").arg(fat_size).arg(new_partition.getFileSystemLabel()).arg(new_partition.getPath());
-        exitcode = Utils::executCmd(cmd ,output, error);
     }
+
+    qDebug() << "FAT16::create***** " << cmd;
+    exitcode = Utils::executCmd(cmd ,output, error);
     return exitcode == 0 && error.compare("Unknown error") == 0;
 }
 
-bool FAT16::checkRepair(const Partition & partition)
+bool FAT16::checkRepair(const Partition &partition)
 {
+    qDebug() << "Checking/repairing FAT filesystem on partition:" << partition.getPath();
     return checkRepair(partition.getPath());
 }
 
@@ -273,13 +309,16 @@ bool FAT16::checkRepair(const QString &devpath)
 
 FS_Limits FAT16::getFilesystemLimits(const Partition &partition)
 {
+    qDebug() << "FAT16::getFilesystemLimits(Partition) BEGIN";
     return getFilesystemLimits(partition.getPath());
 }
 
 FS_Limits FAT16::getFilesystemLimits(const QString &path)
 {
+    qDebug() << "FAT16::getFilesystemLimits(path) BEGIN";
     m_fsLimits = FS_Limits {-1, 0};
     if (Utils::findProgramInPath("fatresize").isEmpty()) {
+        qDebug() << "fatresize not found, return";
         return m_fsLimits;
     }
 
@@ -288,6 +327,7 @@ FS_Limits FAT16::getFilesystemLimits(const QString &path)
     QString output, error;
     int exitcode = Utils::executCmd(QString("fatresize %1 -i").arg(path), output, error);
     if (exitcode != 0) {
+        qDebug() << "fatresize failed, return";
         return m_fsLimits;
     }
     long long minSize = 0, maxSize = 0;
@@ -297,19 +337,24 @@ FS_Limits FAT16::getFilesystemLimits(const QString &path)
 
     foreach (QString str, output.split("\n")) {
         if (str.contains("FAT")) {
+            qDebug() << "found FAT string";
             if (str.contains("fat32")) {
+                qDebug() << "is fat32";
                 fs = FS_FAT32;
             } else if (str.contains("fat16")) {
+                qDebug() << "is fat16";
                 fs = FS_FAT16;
             }
         }
 
         if (str.contains("Min size:")) {
+            qDebug() << "found Min size";
             QStringList list = str.split(":");
             minSize = list.size() == 2 ? list[1].trimmed().toLongLong() : static_cast<long long>(-1);
         }
 
         if (str.contains("Max size:")) {
+            qDebug() << "found Max size";
             QStringList list = str.split(":");
             maxSize = list.size() == 2 ? list[1].trimmed().toLongLong() : static_cast<long long>(-1);
         }
@@ -317,30 +362,37 @@ FS_Limits FAT16::getFilesystemLimits(const QString &path)
 
 
     if (fs == FS_UNKNOWN) {
+        qDebug() << "fs is unknown, return";
         return m_fsLimits;
     }
 
     if (fs == FS_FAT16) {
+        qDebug() << "fs is fat16";
         if (maxSize > 64 * MEBIBYTE) {
+            qDebug() << "maxSize > 64MB";
             maxSize = 64 * MEBIBYTE;
         }
     }
 
 
     if (fs == FS_FAT32) {
+        qDebug() << "fs is fat32";
         if (minSize < 512 * MEBIBYTE) {
+            qDebug() << "minSize < 512MB";
             minSize = 512 * MEBIBYTE;
         }
     }
 
     m_fsLimits.max_size = maxSize;
     m_fsLimits.min_size = minSize;
+    qDebug() << "FAT16::getFilesystemLimits(path) END";
     return m_fsLimits;
 }
 
 //fat格式需要操作分区表 lvm不支持fat格式的调整大小  fatresize命令也不是一个好的调整分区大小方式 相对来说libparted库更合适
 bool FAT16::resize(const Partition &partitionNew, bool fillPartition)
 {
+    // qDebug() << "FAT16::resize(Partition) BEGIN";
     double d = Utils::sectorToUnit(partitionNew.getSectorLength(), partitionNew.m_sectorSize, UNIT_KIB);
     return resize(partitionNew.getPath(), QString::number(((long long)d)), fillPartition);
 }
@@ -351,10 +403,12 @@ fatresize
 */
 bool FAT16::resize(const QString &path, const QString &size, bool fillPartition)
 {
+    // qDebug() << "FAT16::resize(path, size) BEGIN";
     Q_UNUSED(fillPartition)
     //通过fatresize获取文件系统类型以及最小文件系统
     QString output, error;
     int exitcode = Utils::executCmd(QString("fatresize %1 -s %2ki").arg(path).arg(size), output, error);
+    qDebug() << "FAT16::resize(path, size) END";
     return  0 == exitcode || error.compare("Unknown error") == 0;
 }
 

--- a/service/diskoperation/filesystems/filesystem.cpp
+++ b/service/diskoperation/filesystems/filesystem.cpp
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "filesystem.h"
+#include <QDebug>
 
 namespace DiskManager {
 
 FileSystem::FileSystem()
 {
+    // qDebug() << "Constructing a FileSystem object.";
 }
 } // namespace DiskManager

--- a/service/diskoperation/filesystems/xfs.cpp
+++ b/service/diskoperation/filesystems/xfs.cpp
@@ -14,32 +14,44 @@ FS XFS::getFilesystemSupport()
     FS fs(FS_XFS);
     fs.busy = FS::GPARTED;
     if (!Utils::findProgramInPath("xfs_db").isEmpty()) {
+        qDebug() << "xfs_db found, enabling read and read_label support.";
         fs.read = FS::EXTERNAL;
         fs.read_label = FS::EXTERNAL;
     }
     if (!Utils::findProgramInPath("xfs_admin").isEmpty()) {
+        qDebug() << "xfs_admin found, enabling write_label, read_uuid and write_uuid support.";
         fs.write_label = FS::EXTERNAL;
         fs.read_uuid = FS::EXTERNAL;
         fs.write_uuid = FS::EXTERNAL;
     }
     if (!Utils::findProgramInPath("mkfs.xfs").isEmpty()) {
+        qDebug() << "mkfs.xfs found, enabling create support.";
         fs.create = FS::EXTERNAL;
         fs.create_with_label = FS::EXTERNAL;
     }
-    if (!Utils::findProgramInPath("xfs_repair").isEmpty())
+    if (!Utils::findProgramInPath("xfs_repair").isEmpty()) {
+        qDebug() << "xfs_repair found, enabling check support.";
         fs.check = FS::EXTERNAL;
+    }
     //Mounted operations require mount, umount and xfs support in the kernel
     if (!Utils::findProgramInPath("mount").isEmpty() && !Utils::findProgramInPath("umount").isEmpty()
         && fs.check /*&& Utils::kernel_supports_fs("xfs")*/) {
+        qDebug() << "Mount tools found and check is supported.";
         //Grow
-        if (!Utils::findProgramInPath("xfs_growfs").isEmpty())
+        if (!Utils::findProgramInPath("xfs_growfs").isEmpty()) {
+            qDebug() << "xfs_growfs found, enabling grow support.";
             fs.grow = FS::EXTERNAL;
+        }
         //Copy using xfsdump, xfsrestore
-        if (!Utils::findProgramInPath("xfsdump").isEmpty() && !Utils::findProgramInPath("xfsrestore").isEmpty() && fs.create)
+        if (!Utils::findProgramInPath("xfsdump").isEmpty() && !Utils::findProgramInPath("xfsrestore").isEmpty() && fs.create) {
+            qDebug() << "xfsdump and xfsrestore found, enabling copy support.";
             fs.copy = FS::EXTERNAL;
+        }
     }
-    if (fs.check)
+    if (fs.check) {
+        qDebug() << "Check is supported, enabling move support.";
         fs.move = FS::GPARTED;
+    }
     fs.online_read = FS::GPARTED;
 
     qDebug() << "[XFS]::getFilesystemSupport - Exit";
@@ -56,6 +68,7 @@ void XFS::setUsedSectors(Partition &partition)
                      " -c \"print fdblocks\" %1")
                  .arg(partition.getPath());
     if (Utils::executWithInputOutputCmd(strcmd, NULL, output, error) == 0) {
+        qDebug() << "xfs_db command executed successfully.";
         auto strList = output.split("\n");
         foreach (auto &item, strList) {
 #if QT_VERSION_MAJOR > 5
@@ -68,23 +81,27 @@ void XFS::setUsedSectors(Partition &partition)
             }
             if (value[0].startsWith("blocksize")) {
                 m_blocksSize = value[1].trimmed().toULongLong();
+                qDebug() << "Found blocksize:" << m_blocksSize;
             } else if (value[0].startsWith("dblocks")) {
                 m_totalNumOfBlock = value[1].trimmed().toULongLong();
+                qDebug() << "Found dblocks:" << m_totalNumOfBlock;
             } else if (value[0].startsWith("fdblocks")) {
                 m_numOfFreeOrUsedBlocks = value[1].trimmed().toULongLong();
+                qDebug() << "Found fdblocks:" << m_numOfFreeOrUsedBlocks;
             } else {
                 continue;
             }
         }
 
         if (m_totalNumOfBlock > -1 && m_numOfFreeOrUsedBlocks > -1 && m_blocksSize > -1) {
+            qDebug() << "Calculating and setting sector usage.";
             m_totalNumOfBlock = qRound64(m_totalNumOfBlock * (m_blocksSize / double(partition.m_sectorSize)));
             m_numOfFreeOrUsedBlocks = qRound64(m_numOfFreeOrUsedBlocks * (m_blocksSize / double(partition.m_sectorSize)));
             partition.setSectorUsage(m_totalNumOfBlock, m_numOfFreeOrUsedBlocks);
             partition.m_fsBlockSize = m_blocksSize;
         }
     } else {
-        qDebug() << __FUNCTION__ << "dumpe2fs -h failed :" << output << error;
+        qDebug() << "xfs_db command failed. Output:" << output << "Error:" << error;
     }
     qDebug() << "[XFS]::setUsedSectors - Exit";
 }
@@ -94,8 +111,13 @@ void XFS::readLabel(Partition &partition)
     QString output, error;
     if (!Utils::executCmd(QString("xfs_db -r -c label %1").arg(partition.getPath()), output, error)) {
         auto items = output.split("=");
-        if (items.size() == 2)
-            partition.setFilesystemLabel(items[1].replace("\"", "").trimmed());
+        if (items.size() == 2) {
+            QString label = items[1].replace("\"", "").trimmed();
+            qDebug() << "Successfully read label:" << label;
+            partition.setFilesystemLabel(label);
+        }
+    } else {
+        qDebug() << "Failed to read label. Error:" << error;
     }
     qDebug() << "[XFS]::readLabel - Exit";
 }
@@ -103,21 +125,29 @@ bool XFS::writeLabel(const Partition &partition)
 {
     qDebug() << "[XFS]::writeLabel - Enter";
     QString cmd = "";
-    if (partition.getFileSystemLabel().isEmpty())
+    if (partition.getFileSystemLabel().isEmpty()) {
+        qDebug() << "Label is empty, clearing label on" << partition.getPath();
         cmd = QString("xfs_admin -L -- %1").arg(partition.getPath());
-    else
+    } else {
+        qDebug() << "Setting label" << partition.getFileSystemLabel() << "on" << partition.getPath();
         cmd = QString("xfs_admin -L %1 %2").arg(partition.getFileSystemLabel()).arg(partition.getPath());
+    }
     QString output, error;
     int exitcode = Utils::executCmd(cmd, output, error);
-    return exitcode == 0;
-    qDebug() << "[XFS]::writeLabel - Exit";
+    bool success = (exitcode == 0);
+    qDebug() << "[XFS]::writeLabel - Exit with status:" << success;
+    return success;
 }
 void XFS::readUuid(Partition &partition)
 {
     qDebug() << "[XFS]::readUuid - Enter";
     QString output, error;
     if (!Utils::executCmd(QString("xfs_admin -u %1").arg(partition.getPath()), output, error)) {
-        partition.m_uuid = Utils::regexpLabel(output, "^UUID[[:blank:]]*=[[:blank:]]*(" RFC4122_NONE_NIL_UUID_REGEXP ")");
+        QString uuid = Utils::regexpLabel(output, "^UUID[[:blank:]]*=[[:blank:]]*(" RFC4122_NONE_NIL_UUID_REGEXP ")");
+        qDebug() << "Successfully read UUID:" << uuid;
+        partition.m_uuid = uuid;
+    } else {
+        qDebug() << "Failed to read UUID. Error:" << error;
     }
     qDebug() << "[XFS]::readUuid - Exit";
 }
@@ -126,8 +156,9 @@ bool XFS::writeUuid(const Partition &partition)
     qDebug() << "[XFS]::writeUuid - Enter";
     QString output, error;
     int exitcode = Utils::executCmd(QString("xfs_admin -U generate %1").arg(partition.getPath()), output, error);
-    return exitcode == 0 || error.compare("Unknown error") == 0;
-    qDebug() << "[XFS]::writeUuid - Exit";
+    bool success = (exitcode == 0 || error.compare("Unknown error") == 0);
+    qDebug() << "[XFS]::writeUuid - Exit with status:" << success;
+    return success;
 }
 bool XFS::create(const Partition &newPartition)
 {
@@ -135,11 +166,15 @@ bool XFS::create(const Partition &newPartition)
     QString output, error;
     int exitcode = -1;
     if (newPartition.getFileSystemLabel().isEmpty() || newPartition.getFileSystemLabel().trimmed().isEmpty()) {
+        qDebug() << "Creating XFS without label on" << newPartition.getPath();
         exitcode = Utils::executCmd(QString("mkfs.xfs -f %1").arg(newPartition.getPath()), output, error);
     } else {
+        qDebug() << "Creating XFS with label" << newPartition.getFileSystemLabel() << "on" << newPartition.getPath();
         exitcode = Utils::executCmd(QString("mkfs.xfs -f -L %1 %2").arg(newPartition.getFileSystemLabel()).arg(newPartition.getPath()), output, error);
     }
-    return exitcode == 0 && error.compare("Unknown error") == 0;
+    bool success = (exitcode == 0 && error.compare("Unknown error") == 0);
+    qDebug() << "[XFS]::create - Exit with status:" << success;
+    return success;
 }
 /*
 XFSresize can be used to shrink or enlarge any XFS filesystem located on an unmounted DEVICE (usually a disk partition).
@@ -153,56 +188,73 @@ XFSRESIZE使用K=10^3、M=10^6和G=10^9，符合Si、ATA、IEEE标准和磁盘�
 */
 bool XFS::resize(const Partition &partitionNew, bool fillPartition)
 {
+    // qDebug() << "[XFS]::resize - Enter, partition:" << partitionNew.getPath() << "fill:" << fillPartition;
     Q_UNUSED(fillPartition);
     bool success = true ;
 
     QString mountPoint;
     QString output, error;
     if (!partitionNew.m_busy) {
+        // qDebug() << "Partition not busy, creating a temporary mount point.";
         mountPoint = Utils::mkTempDir("");
-        if (mountPoint.isEmpty())
-            return false ;
+        if (mountPoint.isEmpty()) {
+            qDebug() << "Failed to create temp dir.";
+            return false;
+        }
+        // qDebug() << "Mounting" << partitionNew.getPath() << "to" << mountPoint;
         success &= Utils::executCmd(QString("mount -v -t xfs %1 %2")
                 .arg(partitionNew.getPath())
                 .arg(mountPoint),output, error) == 0;
     } else {
         mountPoint = partitionNew.getMountPoint();
+        // qDebug() << "Partition is busy, using existing mount point:" << mountPoint;
     }
 
     if (success) {
+        // qDebug() << "Growing filesystem on" << mountPoint;
         success &= Utils::executCmd(QString("xfs_growfs %1").arg(mountPoint),
                                     output, error) == 0;
 
         if (partitionNew.m_busy) {
+            // qDebug() << "Partition was busy, unmounting" << mountPoint;
             success &= Utils::executCmd(QString("umount -v %1").arg(mountPoint), output, error) == 0;
         }
 
     }
 
     if (!partitionNew.m_busy) {
+        // qDebug() << "Partition was not busy, removing temp dir" << mountPoint;
         Utils::rmTempDir(mountPoint) ;
     }
+    // qDebug() << "[XFS]::resize - Exit with status:" << success;
     return success ;
 }
 
 bool XFS::checkRepair(const Partition &partition)
 {
-    return checkRepair(partition.getPath());
+    qDebug() << "[XFS]::checkRepair(Partition) - Enter, for partition:" << partition.getPath();
+    bool result = checkRepair(partition.getPath());
+    qDebug() << "[XFS]::checkRepair(Partition) - Exit with status:" << result;
+    return result;
 }
 bool XFS::checkRepair(const QString &devpath)
 {
     qDebug() << "[XFS]::checkRepair(path) - Enter";
     QString output, error;
     int exitcode = Utils::executCmd(QString("xfs_repair -v %1").arg(devpath), output, error);
-    return exitcode == 0 || error.compare("Unknown error") == 0;
+    bool success = (exitcode == 0 || error.compare("Unknown error") == 0);
+    qDebug() << "[XFS]::checkRepair(path) - Exit with status:" << success;
+    return success;
 }
 
 FS_Limits XFS::getFilesystemLimits(const Partition &partition)
 {
+    qDebug() << "[XFS]::getFilesystemLimits - Enter, for partition:" << partition.getPath();
     // Official minsize = 16MB, but the smallest xfs_repair can handle is 32MB.
     //m_fsLimits.min_size = 32 * MEBIBYTE;
     m_fsLimits.min_size = -1;
     m_fsLimits.max_size = -1;
+    qDebug() << "[XFS]::getFilesystemLimits - Exit";
     return m_fsLimits;
 }
 } // namespace DiskManager

--- a/service/diskoperation/fsinfo.cpp
+++ b/service/diskoperation/fsinfo.cpp
@@ -18,6 +18,7 @@ QVector<fileSystemEntry> FsInfo::m_fileSystemInfoCache;
 
 void FsInfo::loadCache()
 {
+    qDebug() << "FsInfo::loadCache called.";
     setCommandsFound();
     loadFileSystemInfoCache();
     m_fsInfoCacheInitialized = true;
@@ -25,6 +26,7 @@ void FsInfo::loadCache()
 
 QString FsInfo::getFileSystemType(const QString &path)
 {
+    qDebug() << "FsInfo::getFileSystemType called for path:" << path;
     initializeIfRequired();
     const fileSystemEntry &fsEntry = getCacheEntryByPath(path);
     QString fsType = fsEntry.m_type;
@@ -32,87 +34,109 @@ QString FsInfo::getFileSystemType(const QString &path)
 
     // If vfat, decide whether fat16 or fat32
     if (fsType == "vfat") {
+        qDebug() << "fsType is vfat, determining if fat16 or fat32.";
         if (m_needBlkidVfatCacheUpdateWorkaround) {
+            qDebug() << "Using blkid vfat cache update workaround.";
             // Blkid cache does not correctly add and remove SEC_TYPE when
             // overwriting FAT16 and FAT32 file systems with each other, so
             // prevents correct identification.  Run blkid command again,
             // bypassing the the cache to get the correct results.
             QString output;
             QString error;
-            if (!Utils::executCmd("blkid -c /dev/null " + path, output, error))
+            if (!Utils::executCmd("blkid -c /dev/null " + path, output, error)) {
                 fsSecType = Utils::regexpLabel(output, " SEC_TYPE=\"([^\"]*)\"");
+                qDebug() << "Bypassed cache, got fsSecType:" << fsSecType;
+            }
         }
         if (fsSecType == "msdos") {
+            qDebug() << "fsSecType is msdos, setting fsType to fat16.";
             fsType = "fat16";
         }
         else {
+            qDebug() << "fsSecType is not msdos, setting fsType to fat32.";
             fsType = "fat32";
         }
     }
 
+    qDebug() << "Returning fsType:" << fsType;
     return fsType;
 }
 
 QString FsInfo::getPathByUuid(const QString &uuid)
 {
+    qDebug() << "FsInfo::getPathByUuid called with uuid:" << uuid;
     initializeIfRequired();
     for (int i = 0; i < m_fileSystemInfoCache.size(); i++) {
         if (uuid == m_fileSystemInfoCache[i].m_uuid) {
+            qDebug() << "Found path:" << m_fileSystemInfoCache[i].m_path.m_name << "for uuid:" << uuid;
             return m_fileSystemInfoCache[i].m_path.m_name;
         }
     }
 
+    qDebug() << "No path found for uuid:" << uuid;
     return "";
 }
 
 QString FsInfo::getPathByLabel(const QString &label)
 {
+    qDebug() << "FsInfo::getPathByLabel called with label:" << label;
     initializeIfRequired();
     updateFileSystemInfoCacheAllLabels();
     for (int i = 0; i < m_fileSystemInfoCache.size(); i++) {
         if (label == m_fileSystemInfoCache[i].m_label) {
+            qDebug() << "Found path:" << m_fileSystemInfoCache[i].m_path.m_name << "for label:" << label;
             return m_fileSystemInfoCache[i].m_path.m_name;
         }
     }
 
+    qDebug() << "No path found for label:" << label;
     return "";
 }
 
 QString FsInfo::getLabel(const QString &path, bool &found)
 {
+    qDebug() << "FsInfo::getLabel called for path:" << path;
     initializeIfRequired();
     BlockSpecial bs = BlockSpecial(path);
     for (int i = 0; i < m_fileSystemInfoCache.size(); i++) {
         if (bs == m_fileSystemInfoCache[i].m_path) {
+            qDebug() << "Found cache entry for path:" << path;
             if (m_fileSystemInfoCache[i].m_haveLabel || m_fileSystemInfoCache[i].m_type == "") {
                 // Already have the label or this is a blank cache entry
                 // for a whole disk device containing a partition table,
                 // so no label (as created by
                 // load_fs_info_cache_extra_for_path()).
                 found = m_fileSystemInfoCache[i].m_haveLabel;
+                qDebug() << "Label already in cache or blank entry. Found:" << found << "Label:" << m_fileSystemInfoCache[i].m_label;
                 return m_fileSystemInfoCache[i].m_label;
             }
 
             // Run blkid to get the label for this one partition, update the
             // cache and return the found label.
+            qDebug() << "Label not in cache, running blkid to get it.";
             found = runBlkidUpdateCacheOneLabel(m_fileSystemInfoCache[i]);
+            qDebug() << "Found:" << found << "Label:" << m_fileSystemInfoCache[i].m_label;
             return m_fileSystemInfoCache[i].m_label;
         }
     }
+    qDebug() << "No cache entry found for path:" << path;
     found = false;
     return "";
 }
 
 QString FsInfo::getUuid(const QString &path)
 {
+    qDebug() << "FsInfo::getUuid called for path:" << path;
     initializeIfRequired();
     const fileSystemEntry &fsEntry = getCacheEntryByPath(path);
+    qDebug() << "Returning uuid:" << fsEntry.m_uuid;
     return fsEntry.m_uuid;
 }
 
 void FsInfo::initializeIfRequired()
 {
     if (!m_fsInfoCacheInitialized) {
+        qDebug() << "Cache not initialized, initializing now.";
         setCommandsFound();
         loadFileSystemInfoCache();
         m_fsInfoCacheInitialized = true;
@@ -121,7 +145,9 @@ void FsInfo::initializeIfRequired()
 
 void FsInfo::setCommandsFound()
 {
+    qDebug() << "FsInfo::setCommandsFound called.";
     m_blkidFound = (!Utils::findProgramInPath("blkid").isEmpty());
+    qDebug() << "blkid found:" << m_blkidFound;
     if (m_blkidFound) {
         // Blkid from util-linux before 2.23 has a cache update bug which prevents
         // correct identification between FAT16 and FAT32 when overwriting one
@@ -134,12 +160,14 @@ void FsInfo::setCommandsFound()
         if (sscanf(blkidVersion.toStdString().c_str(), "%d.%d", &blkidMajorVer, &blkidMinorVer) == 2) {
             m_needBlkidVfatCacheUpdateWorkaround =
                 (blkidMajorVer < 2 || (blkidMajorVer == 2 && blkidMinorVer < 23));
+            qDebug() << "blkid version:" << blkidVersion << "Need workaround:" << m_needBlkidVfatCacheUpdateWorkaround;
         }
     }
 }
 
 void FsInfo::loadFileSystemInfoCache()
 {
+    qDebug() << "FsInfo::loadFileSystemInfoCache called.";
     m_fileSystemInfoCache.clear();
     // Run "blkid" and load entries into the cache.
     runBlkidLoadCache();
@@ -152,6 +180,7 @@ void FsInfo::loadFileSystemInfoCache()
     for (int i = 0; i < allDevices.size(); i++) {
         const fileSystemEntry &fsEntry = getCacheEntryByPath(allDevices[i]);
         if (fsEntry.m_path == emptyBs) {
+            qDebug() << "Cache entry missing for whole disk device:" << allDevices[i] << ", loading it.";
             // Run "blkid PATH" and load entry into cache for missing entries.
             loadFileSystemInfoCacheExtraForPath(allDevices[i]);
         }
@@ -160,6 +189,7 @@ void FsInfo::loadFileSystemInfoCache()
 
 bool FsInfo::runBlkidLoadCache(const QString &path)
 {
+    qDebug() << "FsInfo::runBlkidLoadCache called for path:" << (path.isEmpty() ? "all" : path);
     QString cmd = "blkid";
     if (path.size())
         cmd = cmd + " " + path; //Glib::shell_quote(path);
@@ -167,13 +197,14 @@ bool FsInfo::runBlkidLoadCache(const QString &path)
     QString error;
     bool loadedEntries = false;
     if (m_blkidFound && !Utils::executCmd(cmd, output, error)) {
-//        qDebug() << output;
+        qDebug() << "blkid command successful.";
         QStringList strlist = output.split("\n");
         for (int i = 0; i < strlist.size(); i++) {
             fileSystemEntry fsEntry = {BlockSpecial(), "", "", "", false, ""};
             QString entryPath = Utils::regexpLabel(strlist[i], "(?<=/).*?(?=: )");
             if (entryPath.length() > 0) {
                 entryPath = "/" + entryPath;
+                // qDebug() << "Parsing blkid output for path:" << entryPath;
                 fsEntry.m_path = BlockSpecial(entryPath);
                 fsEntry.m_type = Utils::regexpLabel(strlist[i], "(?<= TYPE=\").*?(?=\")");
                 fsEntry.m_secType = Utils::regexpLabel(strlist[i], " SEC_TYPE=\"([^\"]*)\"");
@@ -185,27 +216,34 @@ bool FsInfo::runBlkidLoadCache(const QString &path)
 //                qDebug() << fsEntry.m_path.m_name << fsEntry.m_type << fsEntry.m_secType << fsEntry.m_uuid << fsEntry.m_label;
             }
         }
+    } else {
+        qDebug() << "blkid command failed or blkid not found.";
     }
     return loadedEntries;
 }
 
 const fileSystemEntry &FsInfo::getCacheEntryByPath(const QString &path)
 {
+    qDebug() << "FsInfo::getCacheEntryByPath called for path:" << path;
     BlockSpecial bs = BlockSpecial(path);
     for (int i = 0; i < m_fileSystemInfoCache.size(); i++) {
         if (bs == m_fileSystemInfoCache[i].m_path) {
+            qDebug() << "Found cache entry for path:" << path;
             return m_fileSystemInfoCache[i];
         }
     }
 
+    qDebug() << "No cache entry found for path:" << path << ", returning static notFound.";
     static fileSystemEntry notFound = {BlockSpecial(), "", "", "", false, ""};
     return notFound;
 }
 
 void FsInfo::loadFileSystemInfoCacheExtraForPath(const QString &path)
 {
+    qDebug() << "FsInfo::loadFileSystemInfoCacheExtraForPath called for path:" << path;
     bool entryAdded = runBlkidLoadCache(path);
     if (!entryAdded) {
+        qDebug() << "No entry added by runBlkidLoadCache, adding a blank entry for path:" << path;
         // Ran "blkid PATH" but didn't find details suitable for loading as a
         // cache entry so add a blank entry for PATH name here.
         fileSystemEntry fsEntry = {BlockSpecial(path), "", "", "", false, ""};
@@ -215,13 +253,16 @@ void FsInfo::loadFileSystemInfoCacheExtraForPath(const QString &path)
 
 void FsInfo::updateFileSystemInfoCacheAllLabels()
 {
+    qDebug() << "FsInfo::updateFileSystemInfoCacheAllLabels called.";
     if (!m_blkidFound) {
+        qDebug() << "blkid not found, returning.";
         return;
     }
     // For all cache entries which are file systems but don't yet have a label load it
     // now.
     for (int i = 0; i < m_fileSystemInfoCache.size(); i++) {
         if (m_fileSystemInfoCache[i].m_type != "" && !m_fileSystemInfoCache[i].m_haveLabel) {
+            qDebug() << "Updating label for cache entry:" << m_fileSystemInfoCache[i].m_path.m_name;
             runBlkidUpdateCacheOneLabel(m_fileSystemInfoCache[i]);
         }
     }
@@ -229,7 +270,9 @@ void FsInfo::updateFileSystemInfoCacheAllLabels()
 
 bool FsInfo::runBlkidUpdateCacheOneLabel(fileSystemEntry &fsEntry)
 {
+    qDebug() << "FsInfo::runBlkidUpdateCacheOneLabel called for path:" << fsEntry.m_path.m_name;
     if (!m_blkidFound) {
+        qDebug() << "blkid not found, returning false.";
         return false;
     }
 
@@ -238,11 +281,14 @@ bool FsInfo::runBlkidUpdateCacheOneLabel(fileSystemEntry &fsEntry)
     QString output;
     QString error;
     bool success = !Utils::executCmd("blkid -o value -s LABEL " + fsEntry.m_path.m_name, output, error);
-    if (!success)
+    if (!success) {
+        qDebug() << "blkid command to get label failed.";
         return false;
+    }
 
     size_t len = output.length();
     if (len > 0 && output.back() == '\n') {
+        qDebug() << "Stripping trailing newline from blkid output.";
         // Output is either the label with a terminating new line or zero bytes
         // when the file system has no label.  Strip optional trailing new line
         // from blkid output.
@@ -251,6 +297,7 @@ bool FsInfo::runBlkidUpdateCacheOneLabel(fileSystemEntry &fsEntry)
     // Update cache entry with the read label.
     fsEntry.m_haveLabel = true;
     fsEntry.m_label = output;
+    qDebug() << "Updated label:" << fsEntry.m_label;
     return true;
 }
 

--- a/service/diskoperation/mountinfo.cpp
+++ b/service/diskoperation/mountinfo.cpp
@@ -20,13 +20,15 @@ static MountInfo::MountMapping fstabInfo;
 
 void MountInfo::loadCache(QString &rootFs)
 {
+    qDebug() << "MountInfo::loadCache called.";
     mountInfo.clear();
     fstabInfo.clear();
 
     readMountpointsFromFile("/proc/mounts", mountInfo, rootFs);
     readMountpointsFromFileSwaps("/proc/swaps", mountInfo);
 
-    if (!haveRootfsDev(mountInfo))
+    if (!haveRootfsDev(mountInfo)) {
+        qDebug() << "Rootfs device not found in /proc/mounts, falling back to mount command.";
         // Old distributions only contain 'rootfs' and '/dev/root' device names
         // for the / (root) file system in /proc/mounts with '/dev/root' being a
         // block device rather than a symlink to the true device.  This prevents
@@ -38,12 +40,14 @@ void MountInfo::loadCache(QString &rootFs)
         // to reading mounted file systems from the output of the mount command,
         // but only when required.
         readMountpointsFromMountCommand(mountInfo);
+    }
 
     readMountpointsFromFile("/etc/fstab", fstabInfo, rootFs);
 
     // Sort the mount points and remove duplicates ... (no need to do this for fstab_info)
     MountMapping::iterator iterMp;
     for (iterMp = mountInfo.begin(); iterMp != mountInfo.end(); ++iterMp) {
+        qDebug() << "Sorting and removing duplicate mountpoints for device:" << iterMp.key().m_name;
         std::sort(iterMp.value().mountpoints.begin(), iterMp.value().mountpoints.end());
 
         iterMp.value().mountpoints.erase(
@@ -54,50 +58,62 @@ void MountInfo::loadCache(QString &rootFs)
 
 bool MountInfo::isDevMounted(const QString &path)
 {
+    qDebug() << "MountInfo::isDevMounted called for path:" << path;
     return isDevMounted(BlockSpecial(path));
 }
 
 bool MountInfo::isDevMounted(const BlockSpecial &blockSpecial)
 {
+    qDebug() << "MountInfo::isDevMounted called for BlockSpecial:" << blockSpecial.m_name;
     MountMapping::const_iterator iterMp = mountInfo.find(blockSpecial);
-    return iterMp != mountInfo.end();
+    bool isMounted = iterMp != mountInfo.end();
+    qDebug() << "Device" << blockSpecial.m_name << "is mounted:" << isMounted;
+    return isMounted;
 }
 
 bool MountInfo::isDevMountedReadonly(const QString &path)
 {
+    qDebug() << "MountInfo::isDevMountedReadonly called for path:" << path;
     return isDevMountedReadonly(BlockSpecial(path));
 }
 
 bool MountInfo::isDevMountedReadonly(const BlockSpecial &blockSpecial)
 {
+    qDebug() << "MountInfo::isDevMountedReadonly called for BlockSpecial:" << blockSpecial.m_name;
     MountMapping::const_iterator iterMp = mountInfo.find(blockSpecial);
     if (iterMp == mountInfo.end()) {
+        qDebug() << "Device not found in mount info.";
         return false;
     }
+    qDebug() << "Device" << blockSpecial.m_name << "is readonly:" << iterMp.value().readonly;
     return iterMp.value().readonly;
 }
 
 const QVector<QString> &MountInfo::getMountedMountpoints(const QString &path)
 {
+    qDebug() << "MountInfo::getMountedMountpoints called for path:" << path;
     return find(mountInfo, path).mountpoints;
 }
 
 const QVector<QString> &MountInfo::getFileSystemTableMountpoints(const QString &path)
 {
+    qDebug() << "MountInfo::getFileSystemTableMountpoints called for path:" << path;
     return find(fstabInfo, path).mountpoints;
 }
 
 void MountInfo::readMountpointsFromFile(const QString &fileName, MountInfo::MountMapping &map, QString &rootFs)
 {
+    qDebug() << "MountInfo::readMountpointsFromFile called for file:" << fileName;
     FILE *fp = setmntent(fileName.toStdString().c_str(), "r");
     if (fp == nullptr) {
+        qDebug() << "Failed to open" << fileName;
         return;
     }
     struct mntent *p = nullptr;
     while ((p = getmntent(fp)) != nullptr) {
         QString node = p->mnt_fsname;
         QString mountpoint = p->mnt_dir;
-        qDebug() << __FUNCTION__ << p->mnt_dir << " FsName: " << p->mnt_fsname;
+        qDebug() << "Processing mount entry: dir=" << p->mnt_dir << ", FsName=" << p->mnt_fsname;
         if (0 == rootFs.length() &&
                 (0 == strcmp(p->mnt_dir, "/root")
                  || 0 == strcmp(p->mnt_dir, "/home")
@@ -109,15 +125,18 @@ void MountInfo::readMountpointsFromFile(const QString &fileName, MountInfo::Moun
 
         QString uuid = Utils::regexpLabel(node, "(?<=UUID\\=).*");
         if (!uuid.isEmpty()) {
+            qDebug() << "Found UUID in node, resolving path:" << uuid;
             node = FsInfo::getPathByUuid(uuid);
         }
 
-        QString label = Utils::regexpLabel(node, "(?<=UUID\\=).*");
+        QString label = Utils::regexpLabel(node, "(?<=LABEL\\=).*");
         if (!label.isEmpty()) {
+            qDebug() << "Found LABEL in node, resolving path:" << label;
             node = FsInfo::getPathByLabel(label);
         }
 
         if (!node.isEmpty()) {
+            qDebug() << "Adding mountpoint entry for node:" << node << "mountpoint:" << mountpoint;
             addMountpointEntry(map, node, mountpoint, parseReadonlyFlag(p->mnt_opts));
         }
     }
@@ -127,9 +146,11 @@ void MountInfo::readMountpointsFromFile(const QString &fileName, MountInfo::Moun
 
 void MountInfo::addMountpointEntry(MountInfo::MountMapping &map, QString &node, QString &mountPoint, bool readonly)
 {
+    qDebug() << "MountInfo::addMountpointEntry called for node:" << node << "mountPoint:" << mountPoint << "readonly:" << readonly;
     // Only add node path if mount point exists
     QFile file(mountPoint);
     if (file.exists()) {
+        qDebug() << "Mountpoint" << mountPoint << "exists, adding to map.";
         // Map::operator[] default constructs MountEntry for new keys (nodes).
         MountEntry &mountentry = map[BlockSpecial(node)];
         mountentry.readonly = mountentry.readonly || readonly;
@@ -139,30 +160,36 @@ void MountInfo::addMountpointEntry(MountInfo::MountMapping &map, QString &node, 
 
 bool MountInfo::parseReadonlyFlag(const QString &str)
 {
+    qDebug() << "MountInfo::parseReadonlyFlag called for options string:" << str;
     QStringList mntopts = str.split(",");
     for (int i = 0; i < mntopts.size(); i++) {
         if (mntopts[i] == "rw") {
+            qDebug() << "Found 'rw' option, returning false (not readonly).";
             return false;
         }
         else if (mntopts[i] == "ro") {
+            qDebug() << "Found 'ro' option, returning true (readonly).";
             return true;
         }
     }
+    qDebug() << "No 'ro' or 'rw' option found, defaulting to false (not readonly).";
     return false; // Default is read-write mount
 }
 
 void MountInfo::readMountpointsFromFileSwaps(const QString &fileName, MountInfo::MountMapping &map)
 {
+    qDebug() << "MountInfo::readMountpointsFromFileSwaps called for file:" << fileName;
     QFile file(fileName);
     if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QTextStream in(&file);
         QString line = in.readLine();
         QString node;
         while (!in.atEnd() || !line.isEmpty()) {
-//            qDebug() << line;
+            // qDebug() << "Processing swap line:" << line;
             node = Utils::regexpLabel(line, "^(/[^ ]+)");
 
             if (node.size() > 0) {
+                // qDebug() << "Found swap device:" << node;
                 map[BlockSpecial(node)].mountpoints.push_back("" /* no mountpoint for swap */);
             }
             line = in.readLine();
@@ -172,25 +199,31 @@ void MountInfo::readMountpointsFromFileSwaps(const QString &fileName, MountInfo:
 
 bool MountInfo::haveRootfsDev(MountInfo::MountMapping &)
 {
+    qDebug() << "MountInfo::haveRootfsDev called.";
     MountMapping::const_iterator iterMp;
     for (iterMp = mountInfo.begin(); iterMp != mountInfo.end(); iterMp++) {
         if (!iterMp.value().mountpoints.isEmpty() && iterMp.value().mountpoints[0] == "/") {
+            // qDebug() << "Found root mountpoint for device:" << iterMp.key().m_name;
             if (iterMp.key().m_name != "rootfs" && iterMp.key().m_name != "/dev/root") {
+                // qDebug() << "Device is not 'rootfs' or '/dev/root', returning true.";
                 return true;
             }
         }
     }
+    qDebug() << "No suitable rootfs device found, returning false.";
     return false;
 }
 
 void MountInfo::readMountpointsFromMountCommand(MountInfo::MountMapping &map)
 {
+    qDebug() << "MountInfo::readMountpointsFromMountCommand called.";
     QString output;
     QString error;
     if (!Utils::executCmd("mount", output, error)) {
         QStringList lines;
         lines = output.split("\n");
         for (int i = 0; i < lines.size(); i++) {
+            // qDebug() << "Processing mount command output line:" << lines[i];
             // Process line like "/dev/sda3 on / type ext4 (rw)"
             QString node = Utils::regexpLabel(lines[i], ".*?(?= )");
             QString mountpoint = Utils::regexpLabel(lines[i], "(?<=on ).*?(?= type)");
@@ -205,12 +238,15 @@ void MountInfo::readMountpointsFromMountCommand(MountInfo::MountMapping &map)
 
 const MountEntry &MountInfo::find(const MountInfo::MountMapping &map, const QString &path)
 {
+    // qDebug() << "MountInfo::find called for path:" << path;
     MountMapping::const_iterator iterMp = map.find(BlockSpecial(path));
 
     if (iterMp != map.end()) {
+        // qDebug() << "Found entry for path:" << path;
         return iterMp.value();
     }
 
+    // qDebug() << "No entry found for path:" << path << ", returning static not_mounted.";
     static MountEntry not_mounted = MountEntry();
     return not_mounted;
 }

--- a/service/diskoperation/supportedfilesystems.cpp
+++ b/service/diskoperation/supportedfilesystems.cpp
@@ -69,13 +69,13 @@ SupportedFileSystems::SupportedFileSystems()
 
 SupportedFileSystems::~SupportedFileSystems()
 {
-    qDebug() << "Cleaning up filesystem objects";
+    // qDebug() << "Cleaning up filesystem objects";
     FSObjectsMap::iterator iter;
     for (iter = m_fsObjects.begin(); iter != m_fsObjects.end(); iter++) {
         auto pvalue = iter.value();
 
         if (pvalue != NULL) {
-            qDebug() << "Deleting filesystem handler for:" << Utils::fileSystemTypeToString(iter.key());
+            // qDebug() << "Deleting filesystem handler for:" << Utils::fileSystemTypeToString(iter.key());
             delete pvalue;
         }
 
@@ -94,8 +94,9 @@ void SupportedFileSystems::findSupportedFilesystems()
             FileSystem *psys = iter.value();
             QString fsName = Utils::fileSystemTypeToString(iter.key());
             m_effectivefs.append(fsName);
-            m_fsSupport.push_back(psys->getFilesystemSupport());
-            qDebug() << "Found supported filesystem:" << fsName;
+            FS support = psys->getFilesystemSupport();
+            m_fsSupport.push_back(support);
+            qDebug() << "Found supported filesystem:" << fsName << "with create support:" << support.create;
         } else {
             FS fsBasicsupp(iter.key());
             fsBasicsupp.move = FS::GPARTED;
@@ -122,11 +123,14 @@ FileSystem *SupportedFileSystems::getFsObject(FSType fstype) const
 
 const FS &SupportedFileSystems::getFsSupport(FSType fstype) const
 {
+    qDebug() << "Getting FS Support for fstype:" << Utils::fileSystemTypeToString(fstype);
     for (int i = 0; i < m_fsSupport.size(); i++) {
         if (m_fsSupport[i].fstype == fstype) {
+            qDebug() << "Found support info for fstype:" << Utils::fileSystemTypeToString(fstype);
             return m_fsSupport[i];
         }
     }
+    qDebug() << "Could not find support info for fstype, returning unsupported object:" << Utils::fileSystemTypeToString(fstype);
     static FS fsNotsupp(FS_UNSUPPORTED);
     return fsNotsupp;
 }
@@ -143,6 +147,7 @@ const FS &SupportedFileSystems::getFsSupport(FSType fstype) const
 
 const QStringList &SupportedFileSystems::getAllFsName()
 {
+    qDebug() << "Getting all effective filesystem names";
     return m_effectivefs;
 }
 

--- a/service/main.cpp
+++ b/service/main.cpp
@@ -17,10 +17,12 @@ const QString DiskManagerPath = "/com/deepin/diskmanager";
 
 void checkFrontEndQuit(uint frontEndPid)
 {
+    qDebug() << "checkFrontEndQuit" << frontEndPid;
     QString frontEndExe = QString("/proc/%1/exe").arg(frontEndPid);
     QFileInfo info(frontEndExe);
 
     if (info.symLinkTarget() != "/usr/bin/deepin-diskmanager") {
+        qWarning() << "Front-end process has quit";
         QCoreApplication::exit(0);
     }
 }
@@ -32,6 +34,7 @@ int main(int argc, char *argv[])
 
     qDebug() << "Application starting with PATH:" << PATH;
     if (PATH.isEmpty()) {
+        qWarning() << "PATH environment variable is empty";
         PATH = "/usr/bin";
     }
     PATH += ":/usr/sbin";
@@ -44,10 +47,13 @@ int main(int argc, char *argv[])
         qCritical() << "Invalid arguments count:" << argc;
         return 1;
     } else {
+        qDebug() << "Arguments count:" << argc;
         QString frontEndPidString(argv[1]);
         frontEndPid = frontEndPidString.toUInt();
-        if (frontEndPid == 0)
+        if (frontEndPid == 0) {
+            qCritical() << "Invalid front-end PID:" << frontEndPid;
             return 1;
+        }
         frontEndDBusName = QString(argv[2]);
     }
 
@@ -63,6 +69,7 @@ int main(int argc, char *argv[])
     setLogDir(LogPath);
     if (!dirCheck.exists(LogPath))
     {
+        qDebug() << "Log path does not exist, creating:" << LogPath;
         dirCheck.mkpath(LogPath);
     }
     //检查日志是否过期


### PR DESCRIPTION
Add more logs for base and service. 77.11%

Log: More logs for base and service.

## Summary by Sourcery

Add extensive debug logging throughout the disk manager codebase to improve observability of operations and ease troubleshooting.

Enhancements:
- Add qDebug logging to PartedCore methods for DBus calls, partitioning and disk operations
- Add logging in DiskManagerService to trace authorization, method entry and exit
- Add debug output in DeviceStorage to record hardware info parsing from hwinfo, lsblk, smartctl and lshw
- Instrument LVMOperator and LUKSOperator with logs around command execution, error handling and mapping workflows
- Add logs in Utils for command execution, regex matching, size formatting and other utility functions
- Instrument all filesystem handlers (XFS, NTFS, Btrfs, FAT16, Ext2/3/4, exFAT, LinuxSwap) with support detection and operation tracing
- Add logging in MountInfo, thread classes (ProbeThread, WorkThread, FixThread, LVMThread), BlockSpecial and ProcPartitionsInfo for lifecycle and data flow tracing