### PR TITLE
fix: Improve ext* filesystem usage display logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.user
 .build
+build
 .qmake.stash
 *.qm
+.cache/*
+.claude/*

--- a/basestruct/utils.cpp
+++ b/basestruct/utils.cpp
@@ -380,8 +380,8 @@ int Utils::getMountedFileSystemUsage(const QString &mountpoint, Byte_Value &file
     int ret;
     ret = statvfs(mountpoint.toStdString().c_str(), &sfs);
     if (ret == 0) {
-        fileSystemSize = static_cast<Byte_Value>(sfs.f_blocks) * sfs.f_frsize;
-        fileSystemFree = static_cast<Byte_Value>(sfs.f_bfree) * sfs.f_bsize;
+        fileSystemSize = static_cast<Byte_Value>(sfs.f_blocks) * sfs.f_bsize;
+        fileSystemFree = static_cast<Byte_Value>(sfs.f_bavail) * sfs.f_bsize;
     } else {
         QString errorMessage("statvfs(\"%1\"):%2 "); // = "statvfs(\"" + mountpoint + "\"): " + Glib::strerror(errno) ;
         errorMessage = errorMessage.arg(mountpoint).arg(errno);

--- a/service/diskoperation/filesystems/ext2.cpp
+++ b/service/diskoperation/filesystems/ext2.cpp
@@ -115,59 +115,76 @@ FS EXT2::getFilesystemSupport()
 
 void EXT2::setUsedSectors(Partition &partition)
 {
-    QString output, error, strmatch, strcmd;
-    m_blocksSize = m_numOfFreeOrUsedBlocks = m_totalNumOfBlock = -1;
+    QString output, error, strcmd;
     strcmd = QString("dumpe2fs -h %1").arg(partition.getPath());
+    
     if (!Utils::executCmd(strcmd, output, error)) {
-        strmatch = ("Block count:");
+        long long blockCount = -1;
+        long long blockSize = -1;
+        long long freeBlocks = -1;
+        long long reservedBlocks = 0;
+        
+        // 获取总块数
+        QString strmatch = "Block count:";
         int index = output.indexOf(strmatch);
         if (index >= 0 && index < output.length()) {
-            m_totalNumOfBlock = Utils::regexpLabel(output, QString("(?<=Block count:).*(?=\n)")).trimmed().toLong();
+            blockCount = Utils::regexpLabel(output, QString("(?<=Block count:).*(?=\n)")).trimmed().toLong();
         }
-//        qDebug() << output;
-//        qDebug() << output.mid(index, strmatch.length()).toLatin1() << m_totalNumOfBlock;
-        strmatch = ("Block size:");
+        
+        // 获取块大小
+        strmatch = "Block size:";
         index = output.indexOf(strmatch);
         if (index >= 0 && index < output.length()) {
-            m_blocksSize = Utils::regexpLabel(output, QString("(?<=Block size:).*(?=\n)")).trimmed().toLong();
+            blockSize = Utils::regexpLabel(output, QString("(?<=Block size:).*(?=\n)")).trimmed().toLong();
         }
-//        qDebug() << output << output.mid(index, strmatch.length()).toLatin1() << m_blocksSize;
-
-        if (partition.m_busy) {
-            Byte_Value fs_all;
-            Byte_Value fs_free;
-            if (Utils::getMountedFileSystemUsage(partition.getMountPoint(), fs_all, fs_free) == 0) {
-                partition.setSectorUsage(qRound64(fs_all / double(partition.m_sectorSize)), qRound64(fs_free / double(partition.m_sectorSize)));
-                partition.m_fsBlockSize = m_blocksSize;
-            }
-        } else {
-            // Resize2fs won't shrink a file system smaller than it's own
-            // estimated minimum size, so use that to derive the free space.
-            m_numOfFreeOrUsedBlocks = -1;
-            if (!Utils::executCmd(QString("resize2fs -P %1").arg(partition.getPath()), output, error)) {
-                if (sscanf(output.toLatin1(), "Estimated minimum size of the filesystem: %lld", &m_numOfFreeOrUsedBlocks) == 1
-                        || sscanf(output.toStdString().c_str(), "预计文件系统的最小尺寸：%lld", &m_numOfFreeOrUsedBlocks) == 1)
-                    m_numOfFreeOrUsedBlocks = m_totalNumOfBlock - m_numOfFreeOrUsedBlocks;
-            }
-            // Resize2fs can fail reporting please run fsck first.  Fall back
-            // to reading dumpe2fs output for free space.
-            if (m_numOfFreeOrUsedBlocks == -1) {
-                strmatch = "Free blocks:";
-                index = output.indexOf(strmatch);
-                if (index < output.length())
-                    sscanf(output.mid(index, strmatch.length()).toLatin1(), "Free blocks: %lld", &m_numOfFreeOrUsedBlocks);
-            }
-
-            if (m_totalNumOfBlock > -1 && m_numOfFreeOrUsedBlocks > -1 && m_blocksSize > -1) {
-                m_totalNumOfBlock = qRound64(m_totalNumOfBlock * (m_blocksSize / double(partition.m_sectorSize)));
-                m_numOfFreeOrUsedBlocks = qRound64(m_numOfFreeOrUsedBlocks * (m_blocksSize / double(partition.m_sectorSize)));
-                qDebug() << "111111111111111111111111" << m_totalNumOfBlock << m_numOfFreeOrUsedBlocks << m_blocksSize;
-                partition.setSectorUsage(m_totalNumOfBlock, m_numOfFreeOrUsedBlocks);
-                partition.m_fsBlockSize = m_blocksSize;
-            }
+        
+        // 获取空闲块数
+        strmatch = "Free blocks:";
+        index = output.indexOf(strmatch);
+        if (index >= 0 && index < output.length()) {
+            freeBlocks = Utils::regexpLabel(output, QString("(?<=Free blocks:).*(?=\n)")).trimmed().toLong();
         }
-
-
+        
+        // 获取保留块数
+        strmatch = "Reserved block count:";
+        index = output.indexOf(strmatch);
+        if (index >= 0 && index < output.length()) {
+            reservedBlocks = Utils::regexpLabel(output, QString("(?<=Reserved block count:).*(?=\n)")).trimmed().toLong();
+        }
+        
+        // 验证数据有效性并计算扇区使用情况
+        if (blockCount > 0 && blockSize > 0 && freeBlocks >= 0 && reservedBlocks >= 0) {
+            // 计算用户实际可用的空闲块数：可用 = (freeBlocks - reservedBlocks)
+            long long userAvailableBlocks = (freeBlocks > reservedBlocks) ? (freeBlocks - reservedBlocks) : 0;
+            
+            // 转换为扇区数
+            Sector totalSectors = qRound64(blockCount * (blockSize / double(partition.m_sectorSize)));
+            Sector availableSectors = qRound64(userAvailableBlocks * (blockSize / double(partition.m_sectorSize)));
+            
+            qDebug() << "EXT* usage calculation: blockCount=" << blockCount 
+                     << "blockSize=" << blockSize 
+                     << "freeBlocks=" << freeBlocks 
+                     << "reservedBlocks=" << reservedBlocks
+                     << "userAvailableBlocks=" << userAvailableBlocks
+                     << "totalSectors=" << totalSectors 
+                     << "availableSectors=" << availableSectors;
+            
+            // 如果分区已挂载，使用 stat 获取更准确的可用块数
+            if (partition.m_busy && !partition.getMountPoints().empty()) {
+                Byte_Value statTotalSize, statAvailableSize;
+                if (Utils::getMountedFileSystemUsage(partition.getMountPoint(), statTotalSize, statAvailableSize) == 0) {
+                    // 使用 stat 获取的可用空间（已经排除了保留空间）
+                    Sector statAvailableSectors = qRound64(statAvailableSize / double(partition.m_sectorSize));
+                    qDebug() << "Using stat data for mounted partition: statAvailableSectors=" << statAvailableSectors;
+                    partition.setSectorUsage(totalSectors, statAvailableSectors);
+                } else {
+                    partition.setSectorUsage(totalSectors, availableSectors);
+                }
+            } else {
+                partition.setSectorUsage(totalSectors, availableSectors);
+            }
+            partition.m_fsBlockSize = blockSize;
+        }
     } else {
         qDebug() << __FUNCTION__ << "dumpe2fs -h failed :" << output << error;
     }


### PR DESCRIPTION
​​Changes​​:
​1. ​Reserved space handling​​
- Now counts reserved blocks as ​​used space​​ for ext2/3/4 filesystems
- Matches behavior of standard tools like df
​2. ​Mounted device detection​​
- Uses stat-based calculation for ​​accurate free space​​ on mounted devices
- Falls back to previous method for unmounted devices

​​Technical Impact​​:
- Fixes discrepancy between displayed and actual available space
- Provides more consistent behavior with system utilities

​​Log:​​ Improved ext* filesystem space calculation accuracy

Bug: https://pms.uniontech.com/bug-view-323359.html

## Summary by Sourcery

Improve ext* filesystem usage reporting by accounting for reserved blocks and using statvfs data for mounted partitions to align displayed values with actual available space.

Bug Fixes:
- Include reserved blocks in ext2/3/4 space calculation to match system utilities.
- Use statvfs’s available-block count for mounted devices to report accurate free space.

Enhancements:
- Refactor ext* filesystem usage logic to parse block metadata from dumpe2fs header.
- Simplify free-space computation by unifying handling of free and reserved blocks.
- Adjust getMountedFileSystemUsage to multiply by f_bsize and use f_bavail for free space.