### PR TITLE
fix: [Stroage-interface] The interface show error.

### DIFF
--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -587,8 +587,15 @@ void DeviceStorage::getDiskInfoInterface(const QString &devicePath, QString &int
     if (file.open(QIODevice::ReadOnly)) {
         if (model == file.readLine().simplified()) {
             QString spec_version = Utils::readContent("/sys/block/sdd/device/spec_version").trimmed();
-            if (!spec_version.isEmpty())
-                interface = (spec_version == "300") ? "UFS 3.0" : "UFS 3.1";
+            if (!spec_version.isEmpty()) {
+                if (spec_version.contains("300")) {
+                    interface = "UFS 3.0";
+                } else if (spec_version.contains("310")) {
+                    interface = "UFS 3.1";
+                } else if (spec_version.contains("400")) {
+                    interface = "UFS 4.0";
+                }
+            }
         }
         file.close();
     }


### PR DESCRIPTION
-- In the special platform, the stroage interface show error.

## Summary by Sourcery

Improve storage interface detection by matching spec_version substrings and supporting UFS 3.0, 3.1, and 4.0

Bug Fixes:
- Fix storage interface error by replacing direct equality check with substring matching on spec_version

Enhancements:
- Add support for UFS 4.0 interface detection