### PR TITLE
Pr0731

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-diskmanager (6.0.11) unstable; urgency=medium
+
+  * fix: Fix incomplete retrieval of disk hardware information
+  * fix: Improve disk info retrieval logic
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 31 Jul 2025 15:02:18 +0800
+
 deepin-diskmanager (6.0.10) unstable; urgency=medium
 
   * fix: Fix fail to get device info

--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -801,7 +801,7 @@ void DeviceStorage::getMapInfoFromSmartctl(QMap<QString, QString> &mapInfo, cons
         int index = line.indexOf(ch);
 #if QT_VERSION_MAJOR > 5
         QRegularExpressionMatch match = reg.match(line);
-        if (index > 0 && !match.hasMatch() && match.captured(0) == line && false == line.contains("Error") && false == line.contains("hh:mm:SS")) {
+        if (index > 0 && !match.hasMatch() && false == line.contains("Error") && false == line.contains("hh:mm:SS")) {
 #else
         if (index > 0 && reg.exactMatch(line) == false && false == line.contains("Error") && false == line.contains("hh:mm:SS")) {
 #endif


### PR DESCRIPTION
## Summary by Sourcery

Improve storage device info retrieval by adding NVMe support in lshw parsing, enhancing lshw output handling to consider namespaces, and simplifying smartctl line filtering

Enhancements:
- Skip KeyToLshw matching for NVMe devices in addInfoFromlshw
- Enhance lshw output parsing to handle namespaces when extracting disk info
- Simplify smartctl output filtering by removing redundant regex capture conditions