### PR TITLE
fix: Disable bad sector detection for SSD devices

### DIFF
--- a/application/widgets/devicelistwidget.cpp
+++ b/application/widgets/devicelistwidget.cpp
@@ -127,6 +127,11 @@ void DeviceListWidget::treeMenu(const QPoint &pos)
             createPartitionTable->setDisabled(true);
         }
 
+        // 如果是SSD设备，禁用坏道检测功能
+        if (info.m_mediaType == "SSD") {
+          actionVerifyRepair->setDisabled(true);
+        }
+
         menu->exec(QCursor::pos()); //显示菜单
         delete menu;
     } else if (m_curDiskInfoData.m_level == DMDbusHandler::PARTITION) {


### PR DESCRIPTION
Changes:
1. Added a condition to disable the bad sector detection feature for SSD devices in the device list widget.

Log: Improved user experience by preventing unnecessary checks on SSDs.

Bug: https://pms.uniontech.com/bug-view-327485.html

## Summary by Sourcery

Disable the bad sector detection option for SSD devices in the device list widget to prevent unnecessary checks and improve user experience.

Bug Fixes:
- Disable bad sector detection action for SSD devices in the context menu

Enhancements:
- Improve user experience by hiding irrelevant checks on SSD drives