### PR TITLE
fix: update translations error

### DIFF
--- a/application/translations/deepin-diskmanager_lo.ts
+++ b/application/translations/deepin-diskmanager_lo.ts
@@ -1,0 +1,2303 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>CreateLVWidget</name>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="34"/>
+        <source>Creating logical volumes on %1</source>
+        <translation>ກຳລັງສ້າງ logical volume ຢູ່ %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="36"/>
+        <source>Click %1 to create a logical volume. </source>
+        <translation>ກົດ %1 ເພື່ອສ້າງ logical volume</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="109"/>
+        <source>VG Information</source>
+        <translation>ຂໍ້ມູນ Volume Group</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="123"/>
+        <source>Capacity:</source>
+        <translation>ຂະໜາດ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="133"/>
+        <source>LV name:</source>
+        <translation>ຊື່ Logical Volume:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="142"/>
+        <source>VG name:</source>
+        <translation>ຊື່ Volume Group:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="154"/>
+        <source>LV file system:</source>
+        <translation>ລະບົບໄຟລ໌ Logical Volume:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="227"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="231"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="234"/>
+        <source>Revert</source>
+        <comment>button</comment>
+        <translation>ກັບຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="265"/>
+        <source>LV Information</source>
+        <translation>ຂໍ້ມູນ Logical Volume</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="277"/>
+        <source>Create LV:</source>
+        <translation>ສ້າງ Logical Volume:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="288"/>
+        <source>Delete last logical volume</source>
+        <translation>លើងលំដាប់លើសุดក្រោយ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="328"/>
+        <source>LV capacity:</source>
+        <translation>ຂະໜາດ Logical Volume:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="514"/>
+        <source>Unallocated</source>
+        <translation>ບໍ່ໄດ້ຈັດສັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="538"/>
+        <source>Size</source>
+        <translation>ຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="738"/>
+        <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
+        <translation>ນີ້ແມ່ນຂັ້ນຕອນການເຂົ້າລະຫັດມາດຕະຖານ aes-xts-plain64 ເພື່ອເຂົ້າລະຫັດດິສ. ທ່ານຕ້ອງຖອດລະຫັດກ່ອນທີ່ຈະເຊື່ອມຕໍ່ມັນອີກຄັ້ງ.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="744"/>
+        <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
+        <translation>ນេះជាស្រាវជ្រាវកម្រិត sm4-xts-plain ស្រប់ស្តែងសម្រាប់បញ្ចប់ទុករបស់រាវ់ទូទៅ។ អ្នកត្រូវបានត្រូវបានដំណើរការចំហាយវាខុងពែលត្រូវបានតែងឡើងវិញ។ ប្រព័ន្ធปฏิบัตីដែលមិនផ្តល់ការគាំទាវស្រាវជ្រាវស្ថានភាពនេះនូវរាវ់ទូទៅមិនអាចចំហាយវាបានទេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="838"/>
+        <source>To encrypt a volume, it should be larger than 100 MiB</source>
+        <translation>ដើម្បីបញ្ចប់ទុកមួយផ្នែក (volume), វាត្រូវមានទៅលើ 100 MiB ឡើង។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="866"/>
+        <source>To avoid losing the password, please back up your password and keep it properly!</source>
+        <translation>เพื่อหลีกเลี่ยงการสูญเสียรหัสผ่าน โปรดสำรองข้อมูลรหัสผ่านของคุณและเก็บรักษาให้เหมาะสม!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createlvwidget.cpp" line="867"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+</context>
+<context>
+    <name>CreatePartitionTableDialog</name>
+    <message>
+        <location filename="../widgets/createpartitiontabledialog.cpp" line="34"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createpartitiontabledialog.cpp" line="41"/>
+        <source>No partition table in this disk. Create a new one?</source>
+        <translation>ບໍ່ມີຕາຕະລາງພາທິຊັນໃນດິສນີ້. ສ້າງອັນໃໝ່ບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createpartitiontabledialog.cpp" line="42"/>
+        <source>Create</source>
+        <translation>ສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createpartitiontabledialog.cpp" line="47"/>
+        <source>The disk has a partition table already. Replace it?</source>
+        <translation>ດິສນີ້ມີຕາຕະລາງພາທິຊັນແລ້ວ. ທ່ານຕ້ອງການແທນທີ່ບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createpartitiontabledialog.cpp" line="48"/>
+        <source>Replace</source>
+        <translation>ແທນທີ່</translation>
+    </message>
+</context>
+<context>
+    <name>CreateVGWidget</name>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="54"/>
+        <source>Create volume group</source>
+        <translation>ສ້າງກຸ່ມໄດຣ໌ (volume group)</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="64"/>
+        <source>Resize</source>
+        <translation>ປັບຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="88"/>
+        <source>Select disks or partitions to create a volume group and set its capacity</source>
+        <translation>ເລືອກດິສຫຼືພາທິຊັນເພື່ອສ້າງກຸ່ມໄດຣ໌ ແລະກຳນົດຄວາມຈຸ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="93"/>
+        <source>Capacity selected: %1</source>
+        <translation>ຄວາມຈຸທີ່ເລືອກ: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="98"/>
+        <source>The selected disks will be converted to dynamic disks, and you will not be able to start installed operating systems from the disks.</source>
+        <translation>ດິສທີ່ເລືອກຈະຖືກປ່ຽນເປັນດິສແບບ dynamic ແລະທ່ານຈະບໍ່ສາມາດເລີ່ມລະບົບປະຕິບັດການທີ່ຕິດຕັ້ງໄວ້ຈາກດິສເຫຼົ່ານີ້ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="148"/>
+        <source>No partitions available</source>
+        <translation>ບໍ່ມີພາທິຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="219"/>
+        <source>No disks or partitions available</source>
+        <translation>ບໍ່ມີດິສ ຫຼື ພາທິຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="253"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="256"/>
+        <source>Next</source>
+        <translation>ຖັດໄປ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="281"/>
+        <source>Selected disks/partitions</source>
+        <translation>ດິສ/ພາທິຊັນທີ່ເລືອກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="318"/>
+        <source>Set VG capacity</source>
+        <translation>ກຳນົດຄວາມຈຸຂອງ VG</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="323"/>
+        <source>Auto adjusted to integral multiples of 4 MiB</source>
+        <translation>ປັບອັດຕະໂນມັດເປັນຫຼາຍເທົ່າຂອງ 4 MiB</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="416"/>
+        <source>Choose one disk or partition at least</source>
+        <translation>ກະລຸນາເລືອກດິສ ຫຼື ພາທິຊັນຢ່າງນ້ອຍ 1 ອັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="453"/>
+        <source>Previous</source>
+        <translation>ກ່ອນໜ້າ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="456"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation>ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="569"/>
+        <source>Resizing space...</source>
+        <translation>རིམ་པ་ས୍བས་བ୍ད་པ་བ୍ད་པ་ཡོད།</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="571"/>
+        <source>Creating...</source>
+        <translation>བ୍ད་པ་བ୍ད་པ་ཡོད།</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="623"/>
+        <source>Selected disks and partitions:</source>
+        <translation>ເລືອກ ഊན་ຫ୍ང་དང་བ୍ད་པ།:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="666"/>
+        <source>VG capacity: %1</source>
+        <translation>លិចវិទ្យាស័ព្ធមានទំហំ: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="673"/>
+        <source>VG name: %1</source>
+        <translation>លិចវិទ្យាដេຊ: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="774"/>
+        <source>No less than the used capacity please</source>
+        <translation>សូមបញ្ចុបទំហំតិចជាងទំហំប្រើប្រាស់មិនបាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="779"/>
+        <source>No more than the maximum capacity please</source>
+        <translation>សូមបញ្ចុបទំហំតិចជាងទំហំអតីតេខ្ពស់មិនបាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="797"/>
+        <source>A lot of data exists on %1, </source>
+        <translation>មានទិន្នន៓ាច្រើនមាននៅលើ %1, </translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="798"/>
+        <source>which may take a long time to back it up.</source>
+        <translation>ដែលអាចត្រូវใช้ពេលយូរសម្រាប់ធ្វើការសន្ធឹកទិន្នន៓ា.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="799"/>
+        <source>Do you want to continue?</source>
+        <translation>តើអ្នកចងៈបន្តទេ?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="800"/>
+        <source>Continue</source>
+        <translation>បន្ត</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="801"/>
+        <source>Cancel</source>
+        <translation>បង្គាក់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="1689"/>
+        <source>Adding the disk/partition to a logical volume group 
+will format it and remove its password.</source>
+        <translation>ការបញ្ចូលប្រព័ន្ធប្រតិបត្តិការទៀតទៅក្នុងតួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។ តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។ តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="1690"/>
+        <source>OK</source>
+        <translation>ស្រប</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="1909"/>
+        <source>Not enough space to back up data on %1, please clear disk space</source>
+        <translation>គ្នាប្រហែលគ្នាអាចជាក់ប៉ុន្តែមានកន្លែងសម្រាប់ការសន្ធឹកទិន្នន៓ាមិនគ្រប់គ្រាន់នៅលើ %1, សូមស្អាប់ចំណុចទំហំរលាយ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="2074"/>
+        <source>Existing volume group, creation failed. Please retry after reboot.</source>
+        <translation>តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។ តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីvទៃទៅ។ តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="2078"/>
+        <source>Failed to create a physical volume. Please refresh Disk Utility and try again.</source>
+        <translation>ការបង្កើតតួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។ តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។ តួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="2082"/>
+        <source>Device input/output error. Please try again after reboot.</source>
+        <translation>មានការខុសគែបញ្ចុបទំហំតិចជាងទំហំអតីតេខ្ពស់មិនបាន។ សូមសាកល្បងវិធីសាស្ត្រតួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។ សូមសាកល្បងវិធីសាស្ត្រតួត្រូវបានលំបាកប៉ុន្តែអាចធ្វើបានដោយសារតែអាជីវកម្មសម្រាប់អាជីវកម្មដ៏ល្អ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/createvgwidget.cpp" line="2135"/>
+        <source>Refreshing the page to reload disks</source>
+        <translation>ទីភ្លៀងទោះដើម្បីផ្ទុករបស់ទៅវិញ</translation>
+    </message>
+</context>
+<context>
+    <name>CylinderInfoWidget</name>
+    <message>
+        <location filename="../widgets/cylinderinfowidget.cpp" line="449"/>
+        <source>LBA: %1</source>
+        <translation>LBA: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/cylinderinfowidget.cpp" line="450"/>
+        <source>Cyl.: %1</source>
+        <translation>សំណង់: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/cylinderinfowidget.cpp" line="451"/>
+        <source>Error: %1</source>
+        <translation>Error: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/cylinderinfowidget.cpp" line="452"/>
+        <source>Cyl. elapsed time: %1</source>
+        <translation>សំណង់រលាក់ពេល: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/cylinderinfowidget.cpp" line="452"/>
+        <source>ms</source>
+        <translation>មីលីវិនាទេរ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/cylinderinfowidget.cpp" line="453"/>
+        <source>Status: Repaired</source>
+        <translation>ສະຖານະພາບ: ໄດ້ຮັບການສ້ອມແປງແລ້ວ</translation>
+    </message>
+</context>
+<context>
+    <name>DMDbusHandler</name>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="189"/>
+        <source>Refreshing data...</source>
+        <translation>ກຳລັງຟື້ນຟູຂໍ້ມູນ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="208"/>
+        <source>Initializing data...</source>
+        <translation>ກຳລັງເລີ່ມຕົ້ນຂໍ້ມູນ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="256"/>
+        <source>Mounting %1 ...</source>
+        <translation>ກຳລັງເມົາ %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="263"/>
+        <source>Unmounting %1 ...</source>
+        <translation>ກຳລັງຖອດເມົາ %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="302"/>
+        <source>Resizing %1 ...</source>
+        <translation>ກຳລັງປັບຂະໜາດ %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="309"/>
+        <source>Creating a new partition...</source>
+        <translation>ກຳລັງສ້າງພາທິຊັນໃໝ່...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="468"/>
+        <source>Deleting %1 ...</source>
+        <translation>លើងយក %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="520"/>
+        <source>Creating a partition table of %1 ...</source>
+        <translation>កំពិតតាម bang tablenៃ %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="522"/>
+        <source>Replacing the partition table of %1 ...</source>
+        <translation>กำลังแทนที่ตารางパーティションของ %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="644"/>
+        <source>Creating...</source>
+        <translation>ກຳລັງສ້າງ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="651"/>
+        <source>Deleting...</source>
+        <translation>ກຳລັງລຶບ...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="670"/>
+        <source>Resizing space...</source>
+        <translation>ກຳລັງປັບຂະໜາດພື້ນທີ່...</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="708"/>
+        <source>AES Encryption</source>
+        <translation>ການເຂົ້າລະຫັດ AES</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="710"/>
+        <source>SM4 Encryption</source>
+        <translation>ການເຂົ້າລະຫັດ SM4</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="796"/>
+        <source>Failed to encrypt %1, please try again!</source>
+        <translation>ການເຂົ້າລະຫັດ %1 ລົ້ມເຫລວ, ກະລຸນາລອງອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="800"/>
+        <source>Failed to decrypt %1, please try again!</source>
+        <translation>ການຖອດລະຫັດ %1 ລົ້ມເຫລວ, ກະລຸນາລອງອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="804"/>
+        <source>%1 failed to close the crypto map</source>
+        <translation>&apos;%1 ລົ້ມເຫລວໃນການປິດແຜນທີ່ການເຂົ້າລະຫັດ&apos;</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="811"/>
+        <source>Failed to create partitions, please try again!</source>
+        <translation>ການສ້າງພາທິຊັນລົ້ມເຫລວ, ກະລຸນາລອງອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="815"/>
+        <source>Failed to create %1 file system, please try again!</source>
+        <translation>ການສ້າງລະບົບໄຟລ໌ %1 ລົ້ມເຫລວ, ກະລຸນາລອງອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="819"/>
+        <source>Failed to submit the request to the kernel</source>
+        <translation>ການສົ່ງຄຳຮ້ອງຂໍໄປຫາເຄີເນວລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="823"/>
+        <source>DBUS parameter error</source>
+        <translation>ຂໍ້ຜິດພາດພາຣາມິເຕີ DBUS</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="827"/>
+        <source>Failed to mount %1</source>
+        <translation>ການເມົາທ໌ %1 ລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="831"/>
+        <source>%1 failed to create mounting folders</source>
+        <translation>&apos;%1 ລົ້ມເຫລວໃນການສ້າງໂຟລເດີເມົາທ໌&apos;</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="835"/>
+        <source>%1 failed to change the owner of mounting folders</source>
+        <translation>&apos;%1 ລົ້ມເຫລວໃນການປ່ຽນເຈົ້າຂອງໂຟລເດີເມົາທ໌&apos;</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="839"/>
+        <source>Creating partition table failed</source>
+        <translation>ການສ້າງຕາຕະລາງພາທິຊັນລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../partedproxy/dmdbushandler.cpp" line="846"/>
+        <source>Failed to create a logical volume, please try again!</source>
+        <translation>ການສ້າງ logical volume ລົ້ມເຫລວ, ກະລຸນາລອງອີກຄັ້ງ!</translation>
+    </message>
+</context>
+<context>
+    <name>DecryptDialog</name>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="39"/>
+        <source>Enter the password to decrypt the disk</source>
+        <translation>ໃສ່ລະຫັດຜ່ານເພື່ອຖອດລະຫັດດິສ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="51"/>
+        <source>Enter the password to decrypt the volume group</source>
+        <translation>ໃສ່ລະຫັດຜ່ານເພື່ອຖອດລະຫັດກຸ່ມວໍລຸມ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="71"/>
+        <source>Enter a password </source>
+        <translation>ໃສ່ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="76"/>
+        <source>Password hint</source>
+        <translation>ຄຳແນະນຳລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="124"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="129"/>
+        <source>Decrypt</source>
+        <comment>button</comment>
+        <translation>ຖອດລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="296"/>
+        <source>Decrypting...</source>
+        <translation>កំពិចដែលសំបូរ...</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="195"/>
+        <source>Please try again %1 minutes later</source>
+        <translation>សូមសាល់ %1 នាទេបន្ថៃសើមសាម</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="276"/>
+        <source>The password cannot be empty</source>
+        <translation>លំដាប់ល័ចមិនអាចទទេ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="314"/>
+        <source>Decryption failed</source>
+        <translation>កំពិចដែលសំបូរបរាលៗ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="330"/>
+        <source>Password locked, please try again %1 minutes later</source>
+        <translation>លំដាប់ល័ចត្រូវបានត្រូវបានចុះកម្រិត, សូមសាល់ %1 នាទេបន្ថៃសើមសាម</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="332"/>
+        <source>Wrong password, %1 chances left</source>
+        <translation>លំដាប់ល័ចខុស, %1 ការយល់ចំហ័យនៅសល់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/decryptdialog.cpp" line="334"/>
+        <source>Wrong password, only one chance left</source>
+        <translation>ລະຫັດຜ່ານຜິດ, ຍັງເຫຼືອໂອກາດອີກ 1 ຄັ້ງ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceListWidget</name>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="89"/>
+        <source>Disk info</source>
+        <translation>ຂໍ້ມູນດິສ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="96"/>
+        <source>Health management</source>
+        <translation>ການຄຸ້ມຄອງສຸຂະພາບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="102"/>
+        <source>Check health</source>
+        <translation>ກວດສຸຂະພາບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="108"/>
+        <source>Check partition table error</source>
+        <translation>ກວດຜິດພາດຕາຕະລາງພາທິຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="114"/>
+        <source>Verify or repair bad sectors</source>
+        <translation>ກວດສອບ ຫຼື ສ້ອມແປງເຊັກເຕີທີ່ບອດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="120"/>
+        <source>Create partition table</source>
+        <translation>ສ້າງຕາຕະລາງພາທິຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="151"/>
+        <source>Delete partition</source>
+        <translation>ລຶບພາທິຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="206"/>
+        <source>Delete volume group</source>
+        <translation>ລຶບກຸ່ມວໍລຸມ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="212"/>
+        <source>Create logical volume</source>
+        <translation>ສ້າງວໍລຸມລໍຈິກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="237"/>
+        <source>Delete logical volume</source>
+        <translation>ລຶບວໍລຸມລໍຈິກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="280"/>
+        <source>Close</source>
+        <translation>ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="280"/>
+        <source>Health checking does not support this type of device.</source>
+        <translation>ການກວດສຸຂະພາບບໍ່ຮອງຮັບອຸປະກອນປະເພດນີ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="317"/>
+        <source>Please unmount all partitions in the disk first</source>
+        <translation>ກະລຸນາຖອດພາທິຊັນທັງໝົດອອກຈາກດິສກ່ອນ</translation>
+    </message>
+        <location filename="../widgets/devicelistwidget.cpp" line="317"/>
+        <source>OK</source>
+        <translation>ອົດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="329"/>
+        <source>All partitions in this disk will be merged and all data
+ will be lost if creating a new partition table,
+ please take it carefully</source>
+        <translation>ພາທິຊັນທັງໝົດໃນດິສນີ້ຈະຖືກລວມແລະຂໍ້ມູນທັງໝົດຈະຖືກລຶບຖ້າສ້າງຕາຕະລາງພາທິຊັນໃໝ່, ກະລຸນາລະມັດລະວັງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="329"/>
+        <source>Proceed</source>
+        <translation>ຕໍ້ງຕິດຕື່ງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="329"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="355"/>
+        <source>No errors found in the partition table</source>
+        <translation>ພາຍໃນຕາຕາແບບແບ່ງປັນບ້ານບໍ່ພີ່ນມີຜີ່ນຜີ່ນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="368"/>
+        <source>Do you want to hide this partition?</source>
+        <translation>ທ່ານຢານບິ່ງລະບຸມນີ້ບໍ່?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="368"/>
+        <source>Hide</source>
+        <translation>ບິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="375"/>
+        <source>Failed to hide the partition: unable to lock it</source>
+        <translation>ບິ່ງລະບຸມລີກລັອກລະບຸມບໍ່ໄດ້: ഺ່າງຜ່ອນບໍ່ສາມາດລັອກໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="383"/>
+        <source>You can only hide the unmounted partition</source>
+        <translation>ທີ່ທາງທີ້ນສາມາດບິ່ງໄດ້ແມ່ນທີ່ທີ້ນບໍ່ຖືກເຊື່ອມໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="400"/>
+        <source>Do you want to unhide this partition?</source>
+        <translation>ທ່ານຢານບິ່ງບໍ່ອັບບິ່ງລະບຸມນີ້ບໍ່?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="400"/>
+        <source>Unhide</source>
+        <translation>ບິ່ງບໍ່ອັບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="416"/>
+        <source>Are you sure you want to delete this partition?</source>
+        <translation>ທ່ານແນ່ນອນຢານລັບລະບຸມນີ້ບໍ່?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="416"/>
+        <source>You will lose all data in it</source>
+        <translation>ທີ່ມີຂໍ້ນຫຼົງໃນມັນຈະຖືກສິ່ງເຊື່ອມໄປ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="416"/>
+        <source>Delete</source>
+        <translation>ລັບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="423"/>
+        <source>Failed to delete the partition: unable to lock it</source>
+        <translation>ລັບລະບຸມລີກລັອກລະບຸມບໍ່ໄດ້: ഺ່າງຜ່ອນບໍ່ສາມາດລັອກໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="438"/>
+        <source>Hide the partition successfully</source>
+        <translation>ເຊື່ອງພາກສ່ວນສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="443"/>
+        <source>Failed to hide the partition</source>
+        <translation>ເຊື່ອງພາກສ່ວນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="453"/>
+        <source>Unhide the partition successfully</source>
+        <translation>ສະແດງພາກສ່ວນສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="458"/>
+        <source>Failed to unhide the partition</source>
+        <translation>ສະແດງພາກສ່ວນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="474"/>
+        <source>Delete the partition successfully</source>
+        <translation>ລຶບພາກສ່ວນສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="482"/>
+        <source>Failed to find the disk</source>
+        <translation>ຊອກຫາດິດບໍ່ພົບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="486"/>
+        <source>Failed to get the partition info</source>
+        <translation>ບໍ່ສາມາດຮັບຂໍ້ມູນພາກສ່ວນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="490"/>
+        <source>Failed to delete the partition</source>
+        <translation>ລຶບພາກສ່ວນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="494"/>
+        <source>Failed to submit the request to the kernel</source>
+        <translation>ບໍ່ສາມາດສົ່ງຄຳຮ້ອງຂໍໄປຫາ kernel ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="501"/>
+        <source>Failed to delete the partition: %1</source>
+        <translation>ລຶບພາກສ່ວນບໍ່ສຳເລັດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="511"/>
+        <source>Unmounting successful</source>
+        <translation>ຖອດການເຊື່ອມຕໍ່ສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="516"/>
+        <source>Unmounting failed</source>
+        <translation>ຖອດການເຊື່ອມຕໍ່ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="527"/>
+        <source>Creating partition table successful</source>
+        <translation>ສ້າງຕາຕະລາງພາກສ່ວນສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="531"/>
+        <source>Replacing partition table successful</source>
+        <translation>ປ່ຽນຕາຕະລາງພາກສ່ວນສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="539"/>
+        <source>Creating partition table failed</source>
+        <translation>ສ້າງຕາຕະລາງພາກສ່ວນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="543"/>
+        <source>Replacing partition table failed</source>
+        <translation>ປ່ຽນຕາຕະລາງພາກສ່ວນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="558"/>
+        <source>Unmount all logical volumes in %1 first</source>
+        <translation>ຖອດການເຊື່ອມຕໍ່ທຸກ logical volume ໃນ %1 ກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="570"/>
+        <source>Data cannot be recovered if deleted, please confirm before proceeding</source>
+        <translation>ຂໍ້ມູນຈະບໍ່ສາມາດກູ້ຄືນໄດ້ຖ້າຖືກລຶບ, ກະລຸນາຢືນຢັນກ່ອນດຳເນີນການ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="587"/>
+        <source>The disks will be formatted if you create a logical volume</source>
+        <translation>ດິດຈະຖືກຟອຣແມດຖ້າທ່ານສ້າງ logical volume</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="611"/>
+        <source>Unmount %1 first</source>
+        <translation>ຖອດການເຊື່ອມຕໍ່ %1 ກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="652"/>
+        <source>The logical volume group is busy and cannot be deleted. Please retry after reboot.</source>
+        <translation>ກຸ່ມ logical volume ກຳລັງຖືກໃຊ້ງານ ແລະບໍ່ສາມາດລຶບໄດ້. ກະລຸນາລອງໃໝ່ຫຼັງຈາກຣີບູດ.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="657"/>
+        <source>The logical volume is busy and cannot be deleted. Please retry after reboot.</source>
+        <translation>logical volume ກຳລັງຖືກໃຊ້ງານ ແລະບໍ່ສາມາດລຶບໄດ້. ກະລຸນາລອງໃໝ່ຫຼັງຈາກຣີບູດ.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="662"/>
+        <source>Failed to delete the logical volume group</source>
+        <translation>ລຶບກຸ່ມ logical volume ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="699"/>
+        <source>Failed to delete the logical volume</source>
+        <translation>ລຶບ logical volume ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="806"/>
+        <source>Volume Groups</source>
+        <translation>ກຸ່ມ Volume</translation>
+    </message>
+    <message>
+        <location filename="../widgets/devicelistwidget.cpp" line="860"/>
+        <source>Disks</source>
+        <translation>ལོ་བུ</translation>
+    </message>
+</context>
+<context>
+    <name>DiskBadSectorsDialog</name>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="35"/>
+        <source>Verify or repair bad sectors</source>
+        <translation>ກວດສອບ ຫຼື ສ້ອມແປງສ່ວນທີ່ເສຍ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="65"/>
+        <source>Verify:</source>
+        <translation>ກວດສອບ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="70"/>
+        <source>Cylinders</source>
+        <translation>ຊິນລິນເດີ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="71"/>
+        <source>Sectors</source>
+        <translation>ເຊັກເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="72"/>
+        <source>MB</source>
+        <translation>MB</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="118"/>
+        <source>Method:</source>
+        <translation>ວິທີການ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="138"/>
+        <source>Rounds</source>
+        <translation>ຮອບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="139"/>
+        <source>Timeout</source>
+        <translation>ໝົດເວລາ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="186"/>
+        <source>ms</source>
+        <translation>ມິລິວິນາທີ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="219"/>
+        <source>Result:</source>
+        <translation>ຜົນການ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="243"/>
+        <source>Excellent</source>
+        <translation>ດີເຢັ່ນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="250"/>
+        <source>Damaged</source>
+        <translation>ເສຍຫາຍ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="257"/>
+        <source>Unknown</source>
+        <translation>ບໍ່ຮູ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="285"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ອອກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="290"/>
+        <source>Reset</source>
+        <comment>button</comment>
+        <translation>ຣີເຊັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="296"/>
+        <source>Repair</source>
+        <translation>ສ້ອມແປງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="302"/>
+        <source>Start Verify</source>
+        <translation>ເລີ່ມກວດສອບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="307"/>
+        <source>Stop</source>
+        <comment>button</comment>
+        <translation>ຢຸດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="312"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation>ສືບຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="317"/>
+        <source>Verify Again</source>
+        <translation>ກວດສອບອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="322"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation>ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="353"/>
+        <source>Time elapsed:</source>
+        <translation>ពេលបាញៗ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="358"/>
+        <source>Time left:</source>
+        <translation>ពេលសល់:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="738"/>
+        <source>Verifying cylinder: %1</source>
+        <translation>កំពិតកំពូលភ្នំពិនិត្យ: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="776"/>
+        <source>Verify completed</source>
+        <translation>ការពិនិត្យបានបញ្ចប់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="798"/>
+        <source>Disk verify completed. %1 bad blocks found.</source>
+        <translation>ការពិនិត្យឌីសបានបញ្ចប់. រកឃើញ %1 កំពូលខ្មោច.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="798"/>
+        <source>OK</source>
+        <translation>បាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="965"/>
+        <source>The verifying disk contains mounted partitions, so you cannot repair it.</source>
+        <translation>ឌីសដែលកំពិតកំពូលបានផ្ញុតទាញដែលមានកំពូលត្រូវបានបញ្ចប់, ដែលហៅថាអ្នកមិនអាចជួសវាស់វានៅឡើយ.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="967"/>
+        <source>Please unmount partitions and then repair the disk.</source>
+        <translation>សូមដែលផ្ញុតទាញកំពូលចេញមុននឹងជួសវាស់ឌីស.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="977"/>
+        <source>Warning</source>
+        <translation>មានបញ្ហា</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="982"/>
+        <source>Bad sector repairing cannot recover files,</source>
+        <translation>ការជួសវាស់កំពូលខ្មោចមិនអាចសង្ឃឹមុប្រគួសឯកភាពឡើយ,</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="983"/>
+        <source>but destroys data on and near bad sectors instead.</source>
+        <translation>ប៉ុន្តែវាអាចបំផ្លាញទិន្នន័យនៅលើនិងជិតកំពូលខ្មោច.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="984"/>
+        <source>Please back up all data before repair.</source>
+        <translation>សូមបម្រុងទិន្នន័យទាំងអស់មុនពេលជួសជុល។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="998"/>
+        <source>Cancel</source>
+        <translation>បំផ្លុច</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="999"/>
+        <source>Start Repair</source>
+        <translation>ចាប់ផ្តើមជួសវាស់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1045"/>
+        <source>Repairing cylinder: %1</source>
+        <translation>กำลังซ่อมแซมซิลิnder: %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1082"/>
+        <source>Repair completed. Cylinder: %1 repaired.</source>
+        <translation>ซ่อมแซมเสร็จสิ้น. ซิลิnder: %1 ซ่อมแซมแล้ว.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1085"/>
+        <source>Disk repair completed. %1 bad blocks repaired.</source>
+        <translation>ซ่อมแซมฮาร์ดดิสก์เสร็จสิ้น. %1 บล็อกเสียหายซ่อมแซมแล้ว.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1156"/>
+        <source>Verifying for bad sectors, exit now?</source>
+        <translation>กำลังตรวจสอบส่วนเสียหาย, ออกตอนนี้?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1156"/>
+        <source>The verified information will not be reserved</source>
+        <translation>ข้อมูลที่ตรวจสอบแล้วจะไม่ถูกเก็บรักษา</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1157"/>
+        <source>Exit</source>
+        <translation>ออก</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1183"/>
+        <source>Repairing bad sectors, exit now?</source>
+        <translation>กำลังซ่อมแซมส่วนเสียหาย, ออกตอนนี้?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskbadsectorsdialog.cpp" line="1183"/>
+        <source>The repairing information will not be reserved</source>
+        <translation>ข้อมูลซ่อมแซมจะไม่ถูกเก็บรักษา</translation>
+    </message>
+</context>
+<context>
+    <name>DiskHealthDetectionDialog</name>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="47"/>
+        <source>Check Health</source>
+        <translation>ตรวจสอบสุขภาพ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="72"/>
+        <source>Serial number</source>
+        <translation>លេខសequence</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="81"/>
+        <source>Storage</source>
+        <translation>การเก็บข้อมูล</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="102"/>
+        <source>Health Status</source>
+        <translation>สถานะความแข็งแรง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="118"/>
+        <source>Good</source>
+        <translation>ดี</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="124"/>
+        <source>Damaged</source>
+        <translation>เสียหาย</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="130"/>
+        <source>Unknown</source>
+        <translation>ไม่ทราบ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="149"/>
+        <source>Temperature</source>
+        <translation>температура</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="203"/>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="204"/>
+        <source>Status</source>
+        <translation>상태</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="205"/>
+        <source>Current</source>
+        <translation>ปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="206"/>
+        <source>Worst</source>
+        <translation>แย่ที่สุด</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="207"/>
+        <source>Threshold</source>
+        <translation>តួអាស់តេច</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="208"/>
+        <source>Raw Value</source>
+        <translation>ค่าดิจิทال</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="209"/>
+        <source>Attribute name</source>
+        <translation>ชื่อแอตทริบิวต์</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="306"/>
+        <source>Status: (G: Good | W: Warning | D: Damaged | U: Unknown)</source>
+        <translation>상태: (G: ดี | W: เตือน | D: ชำรุด | U: ไม่รู้จัก)</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="310"/>
+        <source>Export</source>
+        <comment>button</comment>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="361"/>
+        <source>Save File</source>
+        <translation>บันทึกไฟล์</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="361"/>
+        <source>Text files (*.txt)</source>
+        <translation>ไฟล์ข้อความ (*.txt)</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="375"/>
+        <source>Wrong path</source>
+        <translation>เส้นทางผิด</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="383"/>
+        <source>You do not have permission to access this path</source>
+        <translation>คุณไม่มีสิทธิ์เข้าถึงเส้นทางนี้</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="413"/>
+        <source>Export successful</source>
+        <translation>การส่งออกสำเร็จ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskhealthdetectiondialog.cpp" line="416"/>
+        <source>Export failed</source>
+        <translation>ປະສាច ล้มเหลว</translation>
+    </message>
+</context>
+<context>
+    <name>DiskInfoDisplayDialog</name>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="35"/>
+        <source>Disk Info</source>
+        <translation>ຂ້ອງຫ្គាក់ទម្រង់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="45"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="47"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="51"/>
+        <source>Model:</source>
+        <translation>ແບບແບង់:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="51"/>
+        <source>Vendor:</source>
+        <translation>ຜູ້ຜະລິດ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="51"/>
+        <source>Media Type:</source>
+        <translation>ສະພាយຂ້ອງຫ្គាក់:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="51"/>
+        <source>Size:</source>
+        <translation>ຂ້າງໃຈ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="52"/>
+        <source>Rotation Rate:</source>
+        <translation>ត្រូវបានបញ្ជូនតាមល្បីល្បាត:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="52"/>
+        <source>Interface:</source>
+        <translation>ອິນເທີເຟດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="52"/>
+        <source>Serial Number:</source>
+        <translation>ເລກລຳດັບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="52"/>
+        <source>Version:</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="53"/>
+        <source>Capabilities:</source>
+        <translation>ຄວາມສາມາດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="53"/>
+        <source>Description:</source>
+        <translation>ລາຍລະອຽດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="53"/>
+        <source>Power On Hours:</source>
+        <translation>ເວລາເປີດເຄື່ອງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="54"/>
+        <source>Power Cycle Count:</source>
+        <translation>ຈຳນວນຄັ້ງເປີດ/ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="54"/>
+        <source>Firmware Version:</source>
+        <translation>ເວີຊັນຟິມແວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="54"/>
+        <source>Speed:</source>
+        <translation>ຄວາມໄວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="57"/>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="104"/>
+        <source>Export</source>
+        <comment>button</comment>
+        <translation>ສົ່ງອອກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="139"/>
+        <source>Save File</source>
+        <translation>ບັນທຶກໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="139"/>
+        <source>Text files (*.txt)</source>
+        <translation>ໄຟລ໌ຂໍ້ຄວາມ (*.txt)</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="154"/>
+        <source>Wrong path</source>
+        <translation>ເສັ້ນທາງຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="162"/>
+        <source>You do not have permission to access this path</source>
+        <translation>ທ່ານບໍ່ມີສິດເຂົ້າເຖິງເສັ້ນທາງນີ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="187"/>
+        <source>Export successful</source>
+        <translation>ສົ່ງອອກສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/diskinfodisplaydialog.cpp" line="190"/>
+        <source>Export failed</source>
+        <translation>ສົ່ງອອກລົ້ມເຫຼວ</translation>
+    </message>
+</context>
+<context>
+    <name>FormateDialog</name>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="80"/>
+        <source>Wipe %1</source>
+        <translation>ລຶບ %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="81"/>
+        <source>It will erase all data on this disk, which will not be recovered</source>
+        <translation>ມັນຈະລຶບຂໍ້ມູນທັງໝົດໃນດິສນີ້ ແລະບໍ່ສາມາດກູ້ຄືນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="89"/>
+        <source>Name:</source>
+        <translation>ຊື່:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="105"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="107"/>
+        <source>File system:</source>
+        <translation>ລະບົບໄຟລ໌:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="137"/>
+        <source>AES Encryption</source>
+        <translation>ການເຂົ້າລະຫັດ AES</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="140"/>
+        <source>SM4 Encryption</source>
+        <translation>ການເຂົ້າລະຫັດ SM4</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="154"/>
+        <source>Security:</source>
+        <translation>ຄວາມປອດໄພ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="167"/>
+        <source>Fast</source>
+        <translation>ໄວ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="167"/>
+        <source>Secure</source>
+        <translation>ປອດໄພ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="171"/>
+        <source>Advanced</source>
+        <translation>ຂັ້ນສູງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="182"/>
+        <source>It only deletes the partition info without erasing the files on the disk. Disk recovery tools may recover the files at a certain probability.</source>
+        <translation>ມັນຈະລຶບຂໍ້ມູນພາທິຊັນເທົ່ານັ້ນ ແຕ່ບໍ່ລຶບໄຟລ໌ໃນດິສ. ເຄື່ອງມືກູ້ຄືນດິສອາດຈະກູ້ໄຟລ໌ຄືນໄດ້ໃນບາງກໍລະນີ.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="188"/>
+        <source>Wiping method:</source>
+        <translation>ວິທີການລຶບ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="196"/>
+        <source>DoD 5220.22-M, 7 passes</source>
+        <translation>DoD 5220.22-M, 7 ຮອບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="196"/>
+        <source>Gutmann, 35 passes</source>
+        <translation>Gutmann, 35 ຮອບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="257"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="261"/>
+        <source>Wipe</source>
+        <comment>button</comment>
+        <translation>ล้าง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="309"/>
+        <source>Failed to find the disk</source>
+        <translation>ค้นหาฮาร์ดดิสก์ล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="312"/>
+        <source>The action cannot be undone, please proceed with caution</source>
+        <translation>การกระทำนี้ไม่สามารถย้อนกลับได้ โปรดดำเนินการอย่างระมัดระวัง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="314"/>
+        <source>LV name:</source>
+        <translation>ชื่อ LV:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="318"/>
+        <source>LV name</source>
+        <translation>ชื่อ LV</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="320"/>
+        <source>LV file system:</source>
+        <translation>ระบบไฟล์ LV:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="322"/>
+        <source>You may be able to recover files after the wipe.</source>
+        <translation>หลังจากล้างค้างเก็บไฟล์ คุณอาจกู้คืนไฟล์ได้</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="325"/>
+        <source>Failed to submit the request to the kernel</source>
+        <translation>ล้มเหลวในการส่งคำร้องไปยังแกนเครื่องยนต์</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="373"/>
+        <source>The length exceeds the limit</source>
+        <translation>ความยาวเกินขีดจำกัด</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="436"/>
+        <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. You should decrypt it before mounting it again.</source>
+        <translation>ប្រើប្រាស់អាលក្រោមស្តង់ដាក់ aes-xts-plain64 ដើម្បីបង្កើតលំដាប់ល័ចរបស់រលករបស់អ្នក។ អ្នកគួរត្រូវបង្កើតលំដាប់ល័ចវិញមុនពេលផ្ទាំងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="446"/>
+        <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. You should decrypt it before mounting it again. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
+        <translation>ລីບដុតូចដែលນិយුគ្គ sm4-xts-plain ដ៏ល្អឥតខ្សោយត្រូវបានប្រើប្រាស់ដើម្បីប្រមូលទិកិច្ចន័យរបស់អ្នក។ មុនពោលនឹងផ្ទាំងឡើងវិញ អ្នកត្រូវរំណាញវា។ ប្រព័ន្ធអូស៊ុបណ្ឌដែលមិនគាំទាវលະលាតៃលេខស្ថានភាពនេះនឹងមិនអាចរំណាញវាបានទេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="486"/>
+        <source>It is a one-time secure wipe that complies with NIST 800-88 and writes 0, 1, and random data to the entire disk once. You will not be able to recover files, and the process will be slow.</source>
+        <translation>នេះគឺជាការលើងក្រៅមួយដ៏សុវត្ថិភាព ដែលទាន់ស្របតាម NIST 800-88 ហើយសរសៃបង្បូរទិកិច្ចន័យទាំងមូលដ្ឋានទាំងអស់នឹងត្រូវសរសៃលេខ 0 1 និងទិកិច្ចន័យបន្ទាប់ជុំតែមួយប៉ុណ្ណោះ។ អ្នកមិនអាចយកទិកិច្ចន័យមកវិនិច្ឆ័យបានទេ ហើយពេលវេលានេះនឹងត្រូវចល័តយ៉ាងតឹងតេរេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="501"/>
+        <source>It writes 0, 1, and random data to the entire disk several times. You can set the number of times to erase disks and overwrite data, but the process will be very slow.</source>
+        <translation>វានឹងសរសៃលេខ 0 1 និងទិកិច្ចន័យបន្ទាប់ជុំចំនួនរយៈក្នុងរយៈពេលយូរ។ អ្នកអាចកំណត់ចំនួនជុំដែលត្រូវលើងក្រៅឡើងវិញ និងសរសៃទិកិច្ចន័យឡើងវិញ ប៉ុន្តែពេលវេលានេះនឹងត្រូវយូរណាស់។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="534"/>
+        <source>You will not be able to recover files after the wipe, and the process will be slow.</source>
+        <translation>បន្ទាប់ពីការលើងក្រៅ អ្នកមិនអាចយកទិកិច្ចន័យមកវិនិច្ឆ័យបានទេ ហើយការដំណើរការនេះនឹងត្រូវចល័តយ៉ាងតឹងតេរេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="606"/>
+        <source>To avoid losing the password, please back up your password and keep it properly!</source>
+        <translation>ເພື່ອປ້ອງກັນການສູນເສຍລະຫັດຜ່ານ, ກະລຸນາສຳຮອງແລະເກັບລະຫັດຜ່ານໃຫ້ດີ!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="607"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="684"/>
+        <source>Wiping %1</source>
+        <translation>กำลังล้าง %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="712"/>
+        <source>&quot;%1&quot; wiped</source>
+        <translation>&quot;%1&quot; ถูกล้าง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/formatedialog.cpp" line="719"/>
+        <source>Failed to wipe %1</source>
+        <translation>លិចស្លាប់បានលិចលាញ %1 មិនបាន</translation>
+    </message>
+</context>
+<context>
+    <name>InfoShowWidget</name>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="123"/>
+        <source>Mount point:</source>
+        <translation>ចំណុចផ្តែមតែ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="131"/>
+        <source>Free:</source>
+        <translation>ទទេ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="138"/>
+        <source>Used:</source>
+        <translation>ប្រើប្រាស់:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="145"/>
+        <source>Type:</source>
+        <translation>ប្រភេទ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="153"/>
+        <source>Capacity:</source>
+        <translation>ទៅលំនាំង:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="159"/>
+        <source>Volume label:</source>
+        <translation>តួត្រូវបានចេញ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="307"/>
+        <source>Path:</source>
+        <translation>เส้นทาง:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="308"/>
+        <source>Disk type:</source>
+        <translation>ប្រភេទរលកទូទៅ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="309"/>
+        <source>Interface:</source>
+        <translation>ចំណុចសង្កេត:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="313"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="315"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="493"/>
+        <source>LV count:</source>
+        <translation>ចំនួន LV:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="495"/>
+        <source>VG name:</source>
+        <translation>ឈ្មោះ VG:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="500"/>
+        <source>Volume group</source>
+        <translation>តួរលក</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="573"/>
+        <source>Volume name:</source>
+        <translation>ឈ្មោះរលាប់:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/infoshowwidget.cpp" line="578"/>
+        <source>Logical volume</source>
+        <translation>រលាប់សមស្រប</translation>
+    </message>
+</context>
+<context>
+    <name>InfoTopFrame</name>
+    <message>
+        <location filename="../widgets/customcontrol/infotopframe.cpp" line="49"/>
+        <source>Capacity</source>
+        <translation>ความจุ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/infotopframe.cpp" line="132"/>
+        <source>File system</source>
+        <translation>ระบบไฟล์</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/infotopframe.cpp" line="166"/>
+        <source>%1 partition table</source>
+        <translation>ตาราง%1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/infotopframe.cpp" line="185"/>
+        <source>Volume group</source>
+        <translation>ផ្នែករលាប់</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../widgets/mainwindow.cpp" line="106"/>
+        <source>Refresh</source>
+        <translation>รีเฟิร์ส</translation>
+    </message>
+</context>
+<context>
+    <name>MountDialog</name>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="29"/>
+        <source>Mount %1</source>
+        <translation>บันทึก%1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="39"/>
+        <source>Choose a mount point please</source>
+        <translation>เลือกจุดบันทึก</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="42"/>
+        <source>Mount point:</source>
+        <translation>จุดบันทึก:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="71"/>
+        <source>Please select /mnt or /media, or its subdirectories.</source>
+        <translation>ກະລຸນາເລືອກ /mnt ຫຼື /media ຫຼື ໂຟນເດີຍ່ອຍຂອງມັນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="79"/>
+        <source>The mount point is illegal. Please select /mnt or /media, or its subdirectories.</source>
+        <translation>ຈຸດເມົາບໍ່ຖືກຕ້ອງ. ກະລຸນາເລືອກ /mnt ຫຼື /media ຫຼື ໂຟນເດີຍ່ອຍຂອງມັນ.</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="90"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="91"/>
+        <source>Mount</source>
+        <translation>ເມົາ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="258"/>
+        <source>The data under this mount point would be lost, please mount the directory to another location</source>
+        <translation>ຂໍ້ມູນພາຍໃຕ້ຈຸດເມົານີ້ຈະຖືກລຶບ, ກະລຸນາເມົາໄດເຣັກໂທຣີໄປທີ່ຕຳແໜ່ງອື່ນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="259"/>
+        <source>Continue</source>
+        <comment>button</comment>
+        <translation>ສືບຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="282"/>
+        <source>Mounting failed: The selected mount point is not empty. Please select another one!</source>
+        <translation>ການເມົາລົ້ມເຫຼວ: ຈຸດເມົາທີ່ເລືອກບໍ່ຫວ່າງ. ກະລຸນາເລືອກອັນອື່ນ!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/mountdialog.cpp" line="283"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+</context>
+<context>
+    <name>PartChartShowing</name>
+    <message>
+        <location filename="../widgets/customcontrol/partchartshowing.cpp" line="104"/>
+        <source>Unallocated</source>
+        <translation>ไม่ได้แบ่งส่วน</translation>
+    </message>
+</context>
+<context>
+    <name>PartitionDialog</name>
+    <message>
+        <location filename="../widgets/partitiondialog.cpp" line="27"/>
+        <source>Partition %1</source>
+        <translation>ส่วนแบ่ง %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiondialog.cpp" line="29"/>
+        <source>It will increase the number of partitions on the disk</source>
+        <translation>จะเพิ่มจำนวนส่วนแบ่งในดิสก์</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiondialog.cpp" line="36"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiondialog.cpp" line="37"/>
+        <source>Confirm</source>
+        <translation>ยืนยัน</translation>
+    </message>
+</context>
+<context>
+    <name>PartitionInfoWidget</name>
+    <message>
+        <location filename="../widgets/customcontrol/partitioninfowidget.cpp" line="240"/>
+        <source>Unallocated</source>
+        <translation>ไม่ได้แบ่งส่วน</translation>
+    </message>
+</context>
+<context>
+    <name>PartitionTableErrorsInfoDialog</name>
+    <message>
+        <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="38"/>
+        <source>Errors in Partition Table</source>
+        <translation>ข้อผิดพลาดในตารางส่วนแบ่ง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="53"/>
+        <source>The partition table of disk %1 has below errors:</source>
+        <translation>ตารางส่วนแบ่งของดิสก์ %1 มีข้อผิดพลาดดังต่อไปนี้:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="90"/>
+        <source>Error</source>
+        <translation>ข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="99"/>
+        <source>Partition table entries are not in disk order</source>
+        <translation>รายการในตารางส่วนแบ่งไม่เป็นไปตามลำดับดิสก์</translation>
+    </message>
+    <message>
+        <location filename="../widgets/partitiontableerrorsinfodialog.cpp" line="111"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+</context>
+<context>
+    <name>PartitionWidget</name>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="37"/>
+        <source>Partitioning %1</source>
+        <translation>การแบ่งส่วน %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="39"/>
+        <source>Click %1 to increase the number of partitions. Click on each partition to change its name and file system.</source>
+        <translation>ចុច %1 ដើម្បីเพิ่มចំនួនផ្នែកបែលបានជ្រើនឡើង។ ចុចលើព្រែកៗដើម្បីផ្លាស់ប្តូរឈ្មោះនិងប្រព័ន្ធគោលដីរបស់វា។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="112"/>
+        <source>Disk Information</source>
+        <translation>ព័ត៌មានរលកទ្រាយ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="126"/>
+        <source>Capacity:</source>
+        <translation>លំដាប់:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="136"/>
+        <source>Partition selected:</source>
+        <translation>ផ្នែកត្រូវເລือក:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="145"/>
+        <source>Disk:</source>
+        <translation>រលក:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="157"/>
+        <source>File system:</source>
+        <translation>ប្រព័ន្ធគោលដី:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="230"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>ຢັນທະບິດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="234"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລົ່າ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="237"/>
+        <source>Revert</source>
+        <comment>button</comment>
+        <translation>ກັບຄີ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="267"/>
+        <source>Partition Information</source>
+        <translation>ព័ត៌ມានພ្នែក</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="279"/>
+        <source>Number of partitions:</source>
+        <translation>ចំນួງພ្នែក:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="290"/>
+        <source>Delete last partition</source>
+        <translation>លើងលេខ 1 របស់ការប៉ារំង</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="300"/>
+        <source>Name:</source>
+        <translation>ຊື່:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="328"/>
+        <source>Size:</source>
+        <translation>ຂະໍ້ນຫວ່າງ:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="469"/>
+        <source>Unallocated</source>
+        <translation>ບໍ່ຖືກຈັດການ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="492"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="493"/>
+        <source>Size</source>
+        <translation>ขนาด</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="720"/>
+        <source>The length exceeds the limit</source>
+        <translation>ความยาวเกินขีดจำกัด</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="741"/>
+        <source>Use the aes-xts-plain64 standard algorithm to encrypt the disk. If it is encrypted, you should decrypt it before mounting.</source>
+        <translation>ប្រើប្រាស់លະលាតៃលេខ aes-xts-plain64 ដែលជាស្តងែប៉ារំងទិកិច្ចន័យ។ ប្រសិនបើវាអ្នកំពូលមានបានប៉ារំង អ្នកត្រូវរំណាញវាបុណ្ណុមមុនពោលនឹងផ្ទាំងឡើង។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="747"/>
+        <source>Use the sm4-xts-plain state cryptographic algorithm to encrypt the disk. If it is encrypted, you should decrypt it before mounting. Operating Systems that do not support the state cryptographic algorithm will not be able to decrypt the disk.</source>
+        <translation>ប្រើប្រាស់លະលាតៃលេខ sm4-xts-plain ដ៏ល្អឥតខ្សោយដែលជាស្តងែប៉ារំងទិកិច្ចន័យ។ ប្រសិនបើវាអ្នកំពូលមានបានប៉ារំង អ្នកត្រូវរំណាញវាបុណ្ណុមមុនពោលនឹងផ្ទាំងឡើង។ ប្រព័ន្ធអូស៊ុបណ្ឌដែលមិនគាំទាវលະលាតៃលេខស្ថានភាពនេះនឹងមិនអាចរំណាញវាបានទេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="881"/>
+        <source>The number of new partitions exceeds the limit</source>
+        <translation>ຈຳນວນພາກສ່ວນໃໝ່ເກີນຂອບເຂດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="904"/>
+        <source>To encrypt a partition, it should be larger than 100 MiB</source>
+        <translation>ເພື່ອເຂົ້າລະຫັດພາກສ່ວນ, ມັນຄວນມີຂະໜາດໃຫຍ່ກວ່າ 100 MiB</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="913"/>
+        <source>Set a password to encrypt the new partition</source>
+        <translation>ຕັ້ງລະຫັດຜ່ານເພື່ອເຂົ້າລະຫັດພາກສ່ວນໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="932"/>
+        <source>To avoid losing the password, please back up your password and keep it properly!</source>
+        <translation>ເພື່ອປ້ອງກັນການສູນເສຍລະຫັດຜ່ານ, ກະລຸນາສຳຮອງແລະເກັບລະຫັດຜ່ານໃຫ້ດີ!</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="933"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/partitionwidget.cpp" line="952"/>
+        <source>To create a partition, you need at least 52 MB</source>
+        <translation>ដើម្បីបង្កើតលំដាប់ថ្មថ្មិតថ្មិតថ្មិតថ្មិតថ្មិតថ្មិតថ្មិតថ្មិតថ្មិតថ្មិតថ្មិ52 MB</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordInputDialog</name>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="53"/>
+        <source>Set a password to encrypt %1</source>
+        <translation>ตั้งค่ารหัสผ่านเพื่อเข้ารหัส %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="55"/>
+        <source>The password cannot be reset or retrieved online</source>
+        <translation>รหัสผ่านไม่สามารถรีเซ็ตหรือค้นพบออนไลน์ได้</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="59"/>
+        <source>Password</source>
+        <translation>รหัสผ่าน</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="64"/>
+        <source>Repeat password</source>
+        <translation>повторите пароль</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="69"/>
+        <source>Password hint</source>
+        <translation>សំណាក់សម្រាប់លំដាប់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="73"/>
+        <source>(Recommended)</source>
+        <translation>(សាល់បំណង)</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="88"/>
+        <source>Enter a password </source>
+        <translation>បញ្ចូរលំដាប់មួយ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="94"/>
+        <source>Enter the password again</source>
+        <translation>បញ្ចូរលំដាប់មួយលើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="100"/>
+        <source>Enter a password hint</source>
+        <translation>បញ្ចូរសំណាក់សម្រាប់លំដាប់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="142"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បង្គterminate</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="143"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>ຢັງເກົ້າອອກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="187"/>
+        <source>The password exceeds the maximum length</source>
+        <translation>ລំដាប់ຂາ້ນກົນຜ່ອນຂໍ້າງກວ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="228"/>
+        <source>The password cannot be empty</source>
+        <translation>ລំដាប់ບ່ོངས་པ་མི་ສາມາດເປັນເຄົ້າຫວ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="242"/>
+        <source>Passwords do not match</source>
+        <translation>ລំដាប់ສອດຄ່ອງກົນກົນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/passwordinputdialog.cpp" line="249"/>
+        <source>The password hint should differ from the password</source>
+        <translation>ສំណាក់ສົ້ມອົບຮົມ ຢັງຄ່ອງລະຫື່ລະຫື່</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>Disk Utility</source>
+        <translation>ອື່ງປະດິງກະບຸນ</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="115"/>
+        <source>Disk Utility is a disk management tool for creating, reorganizing and formatting partitions.</source>
+        <translation>ອື່ງປະດິງກະບຸນ ກົງກົນ ຜັດບຸດສ້າງ, ພຸກຸນແບບແບ່ງແບ່ງ, ຜັດບຸດຮັບຮົງກົນ, ຜັດບຸດປົກຄົນແລະ ຜັດບຸດປົກຄົນ.</translation>
+    </message>
+</context>
+<context>
+    <name>RemovePVWidget</name>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="53"/>
+        <source>Are you sure you want to delete the physical volume?</source>
+        <translation>ທັງຫຼາກທີ່ຢາກລກງຕ່າງໆ ກົງກົນ ຜັດບຸດທີ່ຖືກເປັນເຄົ້າຫວ່າງ?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="59"/>
+        <source>To prevent data loss, back up data in the physical volume before deleting it</source>
+        <translation>ເພື່ອປ້ອງກັນການເສຍຫຼືຂ້າງພົວພົນຂໍ້າງກວ້າງ, ກ່ອນການລກງ ຜັດບຸດທີ່ຖືກເປັນເຄົ້າຫວ່າງ ກ່ອນສ່ວນທີ່ມີຂໍ້າງພົ້ວພົນຂໍ້າງກວ້າງ ກວດສອບໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="66"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បatal</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="73"/>
+        <source>Delete</source>
+        <comment>button</comment>
+        <translation>លិច</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="104"/>
+        <source>Deleting...</source>
+        <translation>កំពិច...</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="211"/>
+        <source>A lot of data exists on %1, </source>
+        <translation>លូកំហិតមានទិន្នន័យច្រើនលើ %1, </translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="212"/>
+        <source>which may take a long time to back it up.</source>
+        <translation>ដែលអាចត្រូវใช้ពេលយូរសម្រាប់ធ្វើការបន្ទាប់ទិន្នន័យ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="213"/>
+        <source>Do you want to continue?</source>
+        <translation>តើត្រូវបន្តទេ?</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="214"/>
+        <source>Continue</source>
+        <translation>ជំនាន់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="215"/>
+        <source>Cancel</source>
+        <translation>បង្កojis</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="227"/>
+        <source>Not enough space to back up data on %1, please delete the logical volume first</source>
+        <translation>ບໍ່ມີພື້ນທີ່ພາກສ່ວນທີ່ຈະສຳຮອງແລະເກັບຂໍ້ມູນພາຍໃນ %1, ກະລຸນາລຶບພາກສ່ວນເຊັ່ນດີກວ່າ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="228"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/removepvwidget.cpp" line="255"/>
+        <source>Failed to delete the physical volume</source>
+        <translation>ການລຶບຜັດບຸດລົ້ມເຫຼວ</translation>
+    </message>
+</context>
+<context>
+    <name>ResizeDialog</name>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="40"/>
+        <source>It will resize the partitions on the disk</source>
+        <translation>ມັນຈະປັບປຸ່ມຂະໜາດຂອງພາກສ່ວນບໍ່ບຸດບໍ່ບຸດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="65"/>
+        <source>New capacity:</source>
+        <translation>ຂະໜາດໃໝ່:</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="88"/>
+        <source>Auto adjusted to integral multiples of 4 MiB</source>
+        <translation>ປັບປຸ່ງອັດຕະໂນມັດຂອງຫຼາຍຄັ້ງຂອງ 4 MiB</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="101"/>
+        <source>Resize %1</source>
+        <translation>ປັບປຸ່ງຂະໜາດ %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="108"/>
+        <source>It will resize the logical volume space</source>
+        <translation>ຈະປັບປຸ່ມຂະໜາດຂອງບໍລິບື່ງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="114"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="115"/>
+        <source>Confirm</source>
+        <translation>ຢັນຮັບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="142"/>
+        <source>No more than the maximum capacity please</source>
+        <translation>ຂະໜາດບໍ່ຄວ່າເກີ່ບຈງຂຸມ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="220"/>
+        <source>The file system does not support shrinking space</source>
+        <translation>ລະບຸມື້ງບໍ່ຮັບໃຊ້ການຫຸ້ມຸ່ງຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="220"/>
+        <source>OK</source>
+        <translation>ຕົວຢື່ນຮັບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="234"/>
+        <source>No less than the used capacity please</source>
+        <translation>ຂະໜາດບໍ່ຄວ່າເກີ່ຮັບ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="241"/>
+        <source>To prevent data loss, back up data before shrinking it</source>
+        <translation>ເພື່ອຫຸ້ມຸ່ງຂະໜາດ, དຳເນີນງານບຼັບກໍານົດຂໍ້ນຂໍ້ງຂໍ້າງກ່ອນຫຸ້ມຸ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="327"/>
+        <source>Unmount it before shrinking its space</source>
+        <translation>ເກີ່ບໍລິບື່ງຂໍ້ນຂໍ້ງກ່ອນຫຸ້ມຸ່ງຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="337"/>
+        <source>The current device has been mounted and will be unmounted automatically. Please back up data in it to prevent data loss</source>
+        <translation>ອຸປະກອນນີ້ໄດ້ຖືກເມົາແລ້ວ ແລະຈະຖືກຖອດເມົາອັດຕະໂນມັດ. ກະລຸນາສຳຮອງຂໍ້ມູນຂ້າງໃນເພື່ອປ້ອງກັນການສູນເສຍຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="340"/>
+        <source>To prevent data loss, back up data in the logical volume before shrinking it</source>
+        <translation>ເພື່ອປ້ອງກັນການສູນເສຍຂໍ້ມູນ ກະລຸນາສຳຮອງຂໍ້ມູນໃນ logical volume ກ່ອນຫຸ້ມຸ່ງຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/resizedialog.cpp" line="376"/>
+        <source>The file system does not support space adjustment</source>
+        <translation>ລະບຸມື້ງບໍ່ຮັບໃຊ້ການປັບປຸ່ມຂະໜາດ</translation>
+    </message>
+</context>
+<context>
+    <name>SizeInfoWidget</name>
+    <message>
+        <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="274"/>
+        <source> Capacity:</source>
+        <translation>&apos;ຂະໜາດ:&apos;</translation>
+    </message>
+    <message>
+        <location filename="../widgets/customcontrol/sizeinfowidget.cpp" line="331"/>
+        <source>Used:</source>
+        <translation>&apos;ຖືກນີ້ງເຄີ່ງ:&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>TitleWidget</name>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="33"/>
+        <source>Partition</source>
+        <translation>&apos;ກັນຊັນ&apos;</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="34"/>
+        <source>Wipe</source>
+        <translation>ລ้าง</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="35"/>
+        <source>Mount</source>
+        <translation>ផ្ទុំ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="36"/>
+        <source>Unmount</source>
+        <translation>ដេញផ្ទុំ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="37"/>
+        <source>Resize</source>
+        <translation>កែវិធីសម្រ៉ាប់ទៅ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="38"/>
+        <source>Create volume group</source>
+        <translation>បង្កើតតួបុគ្វា</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="42"/>
+        <source>Delete volume group</source>
+        <translation>លើងយកតួបុគ្វា</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="46"/>
+        <source>Delete logical volume</source>
+        <translation>លើងយកតួទុក្លាញ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="50"/>
+        <source>Delete physical volume</source>
+        <translation>លើងយកតួសាប់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="54"/>
+        <source>Create logical volume</source>
+        <translation>បង្កើតតួទុក្លាញ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="200"/>
+        <source>Cannot recognize its partition table</source>
+        <translation>ບໍ່ສາມາດຮັບໃຊ້ຕາຕະໂນມັດຂອງພາກສ່ວນນີ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="246"/>
+        <source>Unable to mount the device: no file system is found, or the file system is not supported</source>
+        <translation>ບໍ່ສາມາດເມົາອຸປະກອນນີ້: ບໍ່ມີລະບຸມື້ງບໍ່ຮັບໃຊ້, ຫຼືລະບຸມື້ງບໍ່ຮັບໃຊ້ບໍ່ຮັບໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="247"/>
+        <source>OK</source>
+        <translation>បាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="346"/>
+        <source>The file system does not support space adjustment</source>
+        <translation>ລາວ བ្រុម དំណើរការ དេຊැນ དេຊැນ དាន དាន ཀំណត់ དាន དាន ཀំណត់ ཀំណត់ དេຊැນ དេຊැນ དាន དាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="366"/>
+        <source>The disks will be formatted if you create a logical volume</source>
+        <translation>ລາວ བ្រុម དំណើរការ དេຊැນ དេຊැນ དាន དាន ཀំណត់ དាន དាន ཀំណត់ ཀំណត់ དេຊැນ དេຊැນ དាន དាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="390"/>
+        <source>Unmount %1 first</source>
+        <translation>Unmount %1 first</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="402"/>
+        <source>Data cannot be recovered if deleted, please confirm before proceeding</source>
+        <translation>ຖិកាន៍ទុក្រាងមិនអាចត្រូវបានស្លាប់បានទៀតបើត្រូវបង្កាះចេញទៀតទេ។ សូមបញ្ចាក់មួយครั้งមួយមូលឈានមួយមុខមួយមូលកម្មមួយមូលគែត។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="403"/>
+        <source>Delete</source>
+        <translation>លើកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="403"/>
+        <source>Cancel</source>
+        <translation>បង្គាក់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="453"/>
+        <source>To ensure the normal use of system backup and restore, 
+rootA and rootB should be resized to the same value</source>
+        <translation>ລາວ བ្រុម དំណើរការ དេຊැນ དេຊැນ དាន དាន ཀំណត់ དាន དាន ཀំណត់ ཀំណត់ དេຊැນ དេຊැນ དាន དាន</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="469"/>
+        <source>The disks will be formatted if you create a volume group</source>
+        <translation>ប្រសិនបើអ្នកបង្កើតតួរលាក់មួយភាពចម្បង (volume group) ទៅទែនកម្ភិតទែនកម្ភិតរបស់អង្គ្រង់ទូទៅរបស់ប្រព័ន្ធនេះនូវលានទែនកម្ភិតទែនកម្ភិតទៅ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/titlewidget.cpp" line="490"/>
+        <source>Unmount all logical volumes in %1 first</source>
+        <translation>សូមស្លាប់ទូទៅទាំងអស់នៃតួរលាក់ទូទៅរបស់ %1 ជាមុន។</translation>
+    </message>
+</context>
+<context>
+    <name>UnmountDialog</name>
+    <message>
+        <location filename="../widgets/unmountdialog.cpp" line="27"/>
+        <source>Make sure there are no programs running on the disk</source>
+        <translation>សូមធ្វើការបញ្ចុចពិនិត្យថាអ្នកមិនបានប្រើប្រាស់កម្មវិធីណាបានដេលលើតួរលាក់នេះទេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountdialog.cpp" line="36"/>
+        <source>Unmount %1</source>
+        <translation>ស្លាប់ %1</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountdialog.cpp" line="41"/>
+        <source>Make sure there are no programs running on the logical volume</source>
+        <translation>សូមធ្វើការបញ្ចុចពិនិត្យថាអ្នកមិនបានប្រើប្រាស់កម្មវិធីណាបានដេលលើតួរលាក់ទូទៅរបស់អង្គ្រង់ទូទៅរបស់ប្រព័ន្ធនេះទេ។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountdialog.cpp" line="47"/>
+        <source>Cancel</source>
+        <translation>បង្គាក់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountdialog.cpp" line="48"/>
+        <source>Unmount</source>
+        <translation>ស្លាប់</translation>
+    </message>
+</context>
+<context>
+    <name>UnmountWarningDialog</name>
+    <message>
+        <location filename="../widgets/unmountwarningdialog.cpp" line="32"/>
+        <source>Unmounting system disk may result in system crash</source>
+        <translation>ការស្លាប់ទូទៅតួរលាក់ប្រព័ន្ធនេះអាចបណ្តាលឱ្យប្រព័ន្ធត្រូវបានបញ្ចាញចេញមួយរយៈពេលដ៏វែង។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountwarningdialog.cpp" line="38"/>
+        <source>I will take the risks that may arise</source>
+        <translation>ខ្លឹមខ្លឹមខ្លំខ្លឹមខ្លំខាងហាត់ទៅជាមួយគ្រោះថ្នាក់ដែលអាចកើតមានឡើង។</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountwarningdialog.cpp" line="57"/>
+        <source>Cancel</source>
+        <translation>បង្គាក់</translation>
+    </message>
+    <message>
+        <location filename="../widgets/unmountwarningdialog.cpp" line="58"/>
+        <source>Unmount</source>
+        <translation>ស្លាប់</translation>
+    </message>
+</context>
+<context>
+    <name>VGSizeInfoWidget</name>
+    <message>
+        <location filename="../widgets/customcontrol/vgsizeinfowidget.cpp" line="531"/>
+        <source>Unallocated</source>
+        <translation>ប្រមួលបានដាក់</translation>
+    </message>
+</context>
+</TS>

--- a/application/translations/desktop/desktop_lo.ts
+++ b/application/translations/desktop/desktop_lo.ts
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Deepin Disk Utility</source>
+        <translation>ຄຸ້ມຄອງດິສ Deepin</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Disk Utility</source>
+        <translation>ເຄື່ອງມືຈັດການດິສ</translation>
+    </message>
+</context>
+</TS>

--- a/application/translations/policy/policy_lo.ts
+++ b/application/translations/policy/policy_lo.ts
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+	<name>policy</name>
+	<message>
+		<location filename="com.deepin.pkexec.deepin-diskmanager!message" line="0"/>
+		<source>Authentication is required to read disk information</source>
+		<translation>ຕ້ອງການການຢືນຢັນເພື່ອອ່ານຂໍ້ມູນດິດ</translation>
+	</message>
+	<message>
+		<location filename="com.deepin.pkexec.deepin-diskmanager!description" line="0"/>
+		<source>Run Disk Manager Need Authentication</source>
+		<translation>ການເຮັດວຽກກັບ Disk Manager ຕ້ອງການການຢືນຢັນ</translation>
+	</message>
+</context>
+</TS>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-diskmanager (6.0.13) unstable; urgency=medium
+
+  * Update version to 6.0.13
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 07 Aug 2025 21:10:17 +0800
+
 deepin-diskmanager (6.0.12) unstable; urgency=medium
 
   * fix: Fix fail to get info from some USB device


### PR DESCRIPTION
log:

## Summary by Sourcery

Add and update Lao (lo) translations for the Disk Utility application, its desktop entry, and policy kit messages.

Documentation:
- Add deepin-diskmanager_lo.ts containing Lao translations for all UI strings.
- Add desktop_lo.ts with Lao translations for the desktop entry names.
- Add policy_lo.ts with Lao translations for policy authentication messages.