### PR TITLE
Pr0902

### DIFF
--- a/basestruct/CMakeLists.txt
+++ b/basestruct/CMakeLists.txt
@@ -36,7 +36,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Threads::Threads
 )
 
-set(CMAKE_INSTALL_PREFIX /usr)
-# Install the executable
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+# not install for internal use
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-diskmanager (6.0.18) unstable; urgency=medium
+
+  * chore: Remove unnecessary static library installation
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 03 Sep 2025 10:39:09 +0800
+
 deepin-diskmanager (6.0.17) unstable; urgency=medium
 
   * Update version to 6.0.17. 

--- a/log/CMakeLists.txt
+++ b/log/CMakeLists.txt
@@ -59,7 +59,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::DBus
 )
 
-set(CMAKE_INSTALL_PREFIX /usr)
-# Install the executable
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+# not install for internal use
 

--- a/service/assets/data/diskmanager-daemon.service
+++ b/service/assets/data/diskmanager-daemon.service
@@ -7,7 +7,7 @@ Type=dbus
 BusName=com.deepin.diskmanager
 ExecStart=/usr/lib/deepin-daemon/deepin-diskmanager-service
 CapabilityBoundingSet=~CAP_NET_RAW
-MemoryLimit=8G
+MemoryMax=8G
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary by Sourcery

Disable installation of internal-use-only modules by removing their CMake install directives

Build:
- Remove CMake install directives for basestruct module
- Remove CMake install directives for log module