### PR TITLE
Revert "fix: Fix fail to format disk to FAT32"

### DIFF
--- a/service/diskoperation/supportedfilesystems.cpp
+++ b/service/diskoperation/supportedfilesystems.cpp
@@ -41,7 +41,7 @@ SupportedFileSystems::SupportedFileSystems()
     m_fsObjects[FS_EXT4] = new EXT2(FS_EXT4);
     //    m_fs_objects[FS_F2FS]            = new f2fs();
     //    m_fs_objects[FS_FAT16]           = new fat16(FS_FAT16);
-    //    m_fsObjects[FS_FAT32]            = new FAT16(FS_FAT32);
+    m_fsObjects[FS_FAT32]           = new FAT16(FS_FAT32);
     //    m_fs_objects[FS_HFS]             = new hfs();
     //    m_fs_objects[FS_HFSPLUS]         = new hfsplus();
     //    m_fs_objects[FS_JFS]             = new jfs();


### PR DESCRIPTION
This reverts commit 7f2383a35304bf1ff29c3827ccf86b59ef3da941.

## Summary by Sourcery

Bug Fixes:
- Restore the ability to format disks as FAT32 by reinstating the FAT32 filesystem object registration.