### PR TITLE
chore: update version to 6.0.25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-diskmanager (6.0.25) unstable; urgency=medium
+
+  * Revert "fix: Fix fail to format disk to FAT32"
+  * chore: correct typos in diskhealthheaderview.cpp
+  * fix: Avoid hardcode binary path
+  * chore(CI): add debian check workflow
+
+ -- Wang Yu <wangyu@uniontech.com>  Sat, 11 Apr 2026 10:06:28 +0800
+
 deepin-diskmanager (6.0.24) unstable; urgency=medium
 
   * fix: Improve error handling in DMDbusHandler and DiskManagerService


### PR DESCRIPTION
- bump version to 6.0.25

Log : bump version to 6.0.25

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.0.25.