### PR TITLE
fix(mainwindow): conditionally raise and activate window only when di…

### DIFF
--- a/application/widgets/mainwindow.cpp
+++ b/application/widgets/mainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -176,10 +176,14 @@ void MainWindow::onShowSpinerWindow(bool isShow, const QString &title)
         m_dialog->setShowSpinner(isShow, title);
         m_dialog->show();
     } else {
+        bool dialogWasVisible = m_dialog->isVisible();
         m_dialog->setShowSpinner(isShow, title);
         m_dialog->hide();
 
-        raise();
-        activateWindow();
+        qDebug() << __FUNCTION__ << "dialogWasVisible:" << dialogWasVisible;
+        if (dialogWasVisible) {
+            raise();
+            activateWindow();
+        }
     }
 }


### PR DESCRIPTION
…alog was visible

- Store dialog visibility state before hiding it
- Add debug logging to track dialog visibility changes
- Only call raise() and activateWindow() when the dialog was previously visible
- Prevent unnecessary window activation when dialog wasn't shown

Log: fix(mainwindow): conditionally raise and activate window only when dialog was visible
Bug: https://pms.uniontech.com/bug-view-355757.html