### PR TITLE
fix: prevent dtkcore from starting session bus in backend service

### DIFF
--- a/service/main.cpp
+++ b/service/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
     PATH += ":/sbin";
     qputenv("PATH", PATH.toLatin1());
 
+    // 避免在调用 Dtk::Core::DLogManager::registerConsoleAppender() 时 dtkcore 启动会话总线
+    qunsetenv("DISPLAY");
+
     QString frontEndDBusName;
     if (argc < 2) {
         qCritical() << "Invalid arguments count:" << argc;


### PR DESCRIPTION
Unset DISPLAY environment variable before DLogManager initialization to avoid dtkcore auto-starting a D-Bus session bus, which is unnecessary for the backend service.

## Summary by Sourcery

Bug Fixes:
- Unset the DISPLAY environment variable before initializing DLogManager to avoid auto-starting a D-Bus session bus in the backend service process.