### PR TITLE
fix(partition): simplify redundant condition in chart drawing

### DIFF
--- a/application/widgets/customcontrol/partchartshowing.cpp
+++ b/application/widgets/customcontrol/partchartshowing.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -269,7 +269,7 @@ void PartChartShowing::addPaint(QPainter *painter)
                 }
                 m_flag = 0;
             }
-        } else if (m_sumValue >= 100) { //绘制最后一个分区当超过整个分区容量的时候以及选中状态
+        } else { //绘制最后一个分区当超过整个分区容量的时候以及选中状态
             // qDebug() << "Sum value is 100 or more, handling last partition";
             //            qDebug() << "sumvalue" << sumvalue;
             double width = ((m_partSize.at(m_partSize.size() - 2) / m_total)) * (paintRect.width() - RADIUS) - RIGHTSPACE;


### PR DESCRIPTION
Remove redundant `else if (m_sumValue >= 100)` condition check, simplify to `else` since the preceding `if` already covers the complementary case.

简化分区图表绘制中冗余的条件判断，将 else if 简化为 else。

Log: 简化分区图表绘制冗余条件
PMS: https://pms.uniontech.com/bug-view-354861.html
Influence: 仅代码逻辑简化，不影响功能行为。