### PR TITLE
fix(auth): add polkit support

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -128,7 +128,10 @@ int main(int argc, char *argv[])
             proc.startDetached("/usr/bin/dbus-send --system --type=method_call --dest=com.deepin.diskmanager /com/deepin/diskmanager com.deepin.diskmanager.Quit");
         }
 
-        proc.startDetached("/usr/bin/deepin-diskmanager-authenticateProxy");
+        QStringList argList;
+        argList << QDBusConnection::systemBus().baseService();
+        qDebug() << "Starting deepin-diskmanager-authenticateProxy with args:" << argList;
+        proc.startDetached("deepin-diskmanager-authenticateProxy", argList);
 
         //正常启动程序后,循环查询后台服务是否已经启动,如果后台服务启动说明鉴权成功,启动前端界面
         while (1) {

--- a/service/PolicyKitHelper.cpp
+++ b/service/PolicyKitHelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -8,17 +8,18 @@
 
 #include "PolicyKitHelper.h"
 #include <QDebug>
-bool PolicyKitHelper::checkAuthorization(const QString& actionId, qint64 applicationPid)
+
+bool PolicyKitHelper::checkAuthorization(const QString& actionId, const QString& appBusName)
 {
+    if (appBusName.isEmpty())
+        return false;
+
     Authority::Result result;
-    // 第一个参数是需要验证的action，和规则文件写的保持一致
-    result = Authority::instance()->checkAuthorizationSync(actionId, UnixProcessSubject(applicationPid),
+    result = Authority::instance()->checkAuthorizationSync(actionId, SystemBusNameSubject(appBusName),
                                                            Authority::AllowUserInteraction);
     if (result == Authority::Yes) {
-//        qDebug() << 111111111;
         return true;
     }else {
-//        qDebug() << 22222222;
         return false;
     }
 }

--- a/service/PolicyKitHelper.h
+++ b/service/PolicyKitHelper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -14,7 +14,7 @@ public:
         return &instance;
     }
 
-    bool checkAuthorization(const QString& actionId, qint64 applicationPid);
+    bool checkAuthorization(const QString& actionId, const QString& appBusName);
 
 private:
     PolicyKitHelper();

--- a/service/diskmanagerservice.cpp
+++ b/service/diskmanagerservice.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "diskmanagerservice.h"
+#include "PolicyKitHelper.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -11,9 +12,10 @@
 
 namespace DiskManager {
 
-DiskManagerService::DiskManagerService(QObject *parent)
+DiskManagerService::DiskManagerService(const QString &frontEndDBusName, QObject *parent)
     : QObject(parent)
     , m_partedcore(new PartedCore(this))
+    , m_frontEndDBusName(frontEndDBusName)
 {
     initConnection();
 }
@@ -44,6 +46,7 @@ void DiskManagerService::initConnection()
 
 void DiskManagerService::Quit()
 {
+    // 不鉴权, 前端启动时会调用该接口来关闭已有服务
     qDebug() << "DiskManagerService::Quit called";
     m_partedcore->delTempMountFile();
     QCoreApplication::exit(0);
@@ -63,12 +66,18 @@ void DiskManagerService::Quit()
 //}
 void DiskManagerService::Start()
 {
+    if (!checkAuthorization())
+        return;
+
     QString msg = "DiskManagerService::Start called";
     Q_EMIT MessageReport(msg);
 }
 
 DeviceInfo DiskManagerService::getDeviceinfo()
 {
+    if (!checkAuthorization())
+        return DeviceInfo();
+
     QString msg = "DiskManagerService::getDeviceinfo";
     Q_EMIT MessageReport(msg);
 //    qDebug() << "DiskManagerService::getDeviceinfo success *******";
@@ -78,6 +87,9 @@ DeviceInfo DiskManagerService::getDeviceinfo()
 //TODO： 这里感觉没有必要发送信号 等之后有时间测试一下 能否去掉多余的代码
 void DiskManagerService::getalldevice()
 {
+    if (!checkAuthorization())
+        return;
+
 //    qDebug() << "DiskManagerService::getalldevice";
 //    DeviceInfoMap infores = m_partedcore->getAllDeviceinfo();
 //    Q_EMIT updateDeviceInfo(infores);
@@ -95,170 +107,305 @@ void DiskManagerService::onGetAllDeviceInfomation()
 
 void DiskManagerService::setCurSelect(const PartitionInfo &info)
 {
+    if (!checkAuthorization())
+        return;
+
     m_partedcore->setCurSelect(info);
 }
 
 bool DiskManagerService::unmount()
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->unmount();
 }
 
 bool DiskManagerService::mount(const QString &mountpath)
 {
+    if (!checkAuthorization())
+        return false;
+
     QString invokerUid = QString::number(connection().interface()->serviceUid(message().service()).value());
     return m_partedcore->mountAndWriteFstab(mountpath, invokerUid);
 }
 
 bool DiskManagerService::deCrypt(const LUKS_INFO &luks)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->deCrypt(luks);
 }
 
 bool DiskManagerService::cryptMount(const LUKS_INFO &luks)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->cryptMount(luks);
 }
 
 bool DiskManagerService::cryptUmount(const LUKS_INFO &luks)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->cryptUmount(luks);
 }
 
 QStringList DiskManagerService::getallsupportfs()
 {
+    if (!checkAuthorization())
+        return QStringList();
+
     return m_partedcore->getallsupportfs();
 }
 
 bool DiskManagerService::format(const QString &fstype, const QString &name)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->format(fstype, name);
 }
 
 bool DiskManagerService::clear(const WipeAction &wipe)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->clear(wipe);
 }
 
 bool DiskManagerService::resize(const PartitionInfo &info)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->resize(info);
 }
 
 bool DiskManagerService::create(const PartitionVec &infovec)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->create(infovec);
 }
 
 HardDiskInfo DiskManagerService::onGetDeviceHardInfo(const QString &devicepath)
 {
+    if (!checkAuthorization())
+        return HardDiskInfo();
+
     return m_partedcore->getDeviceHardInfo(devicepath);
 }
 
 QString DiskManagerService::onGetDeviceHardStatus(const QString &devicepath)
 {
+    if (!checkAuthorization())
+        return QString();
+
     return m_partedcore->getDeviceHardStatus(devicepath);
 }
 
 HardDiskStatusInfoList DiskManagerService::onGetDeviceHardStatusInfo(const QString &devicepath)
 {
+    if (!checkAuthorization())
+        return HardDiskStatusInfoList();
+
     return m_partedcore->getDeviceHardStatusInfo(devicepath);
 }
 bool DiskManagerService::onDeletePartition()
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->deletePartition();
 }
 bool DiskManagerService::onHidePartition()
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->hidePartition();
 }
 bool DiskManagerService::onShowPartition()
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->showPartition();
 }
 bool DiskManagerService::onDetectionPartitionTableError(const QString &devicePath)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->detectionPartitionTableError(devicePath);
 }
 bool DiskManagerService::onCreatePartitionTable(const QString &devicePath, const QString &length, const QString &sectorSize, const QString &diskLabel)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->createPartitionTable(devicePath, length, sectorSize, diskLabel);
 }
 bool DiskManagerService::onCheckBadBlocksCount(const QString &devicePath, int blockStart, int blockEnd, int checkConut, int checkSize, int flag)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->checkBadBlocks(devicePath, blockStart, blockEnd, checkConut, checkSize, flag);
 }
 bool DiskManagerService::onCheckBadBlocksTime(const QString &devicePath, int blockStart, int blockEnd, const QString &checkTime, int checkSize, int flag)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->checkBadBlocks(devicePath, blockStart, blockEnd, checkTime, checkSize, flag);
 }
 bool DiskManagerService::onFixBadBlocks(const QString &devicePath, QStringList badBlocksList, int checkSize, int flag)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->fixBadBlocks(devicePath, badBlocksList, checkSize, flag);
 }
 
 bool DiskManagerService::onCreateVG(QString vgName, QList<PVData> devList, long long size)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->createVG(vgName, devList, size);
 }
 
 bool DiskManagerService::onCreateLV(QString vgName, QList<LVAction> lvList)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->createLV(vgName, lvList);
 }
 
 bool DiskManagerService::onDeleteVG(QStringList vglist)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->deleteVG(vglist);
 }
 
 bool DiskManagerService::onDeleteLV(QStringList lvlist)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->deleteLV(lvlist);
 }
 
 bool DiskManagerService::onResizeVG(QString vgName, QList<PVData> devList, long long size)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->resizeVG(vgName, devList, size);
 }
 
 bool DiskManagerService::onResizeLV(LVAction lvAction)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->resizeLV(lvAction);
 }
 
 bool DiskManagerService::onMountLV(LVAction lvAction)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->mountLV(lvAction);
 }
 
 bool DiskManagerService::onUmountLV(LVAction lvAction)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->umountLV(lvAction);
 }
 
 bool DiskManagerService::onClearLV(LVAction lvAction)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->clearLV(lvAction);
 }
 
 bool DiskManagerService::onDeletePVList(QList<PVData> devList)
 {
+    if (!checkAuthorization())
+        return false;
+
     return m_partedcore->deletePVList(devList);
 }
 void DiskManagerService::updateUsb()
 {
+    if (!checkAuthorization())
+        return;
+
     m_partedcore->updateUsb();
 }
 void DiskManagerService::updateUsbRemove()
 {
+    if (!checkAuthorization())
+        return;
+
     m_partedcore->updateUsbRemove();
 }
 void DiskManagerService::refreshFunc()
 {
+    if (!checkAuthorization())
+        return;
+
     m_partedcore->refreshFunc();
 }
 int DiskManagerService::test()
 {
+    if (!checkAuthorization())
+        return 0;
+
     return m_partedcore->test();
 }
+
+bool DiskManagerService::checkAuthorization(void)
+{
+    QString actionId("com.deepin.diskmanager");
+    QString serviceName = message().service();
+
+    if (serviceName == m_frontEndDBusName) {
+        qDebug() << "Authorization granted for frontend:" << serviceName;
+        return true;
+    }
+
+    QDBusReply<uint> uidReply = connection().interface()->serviceUid(serviceName);
+    if (uidReply.isValid() && uidReply.value() == 0) {
+        qDebug() << "Authorization granted for root user";
+        return true;
+    }
+
+    if (PolicyKitHelper::instance()->checkAuthorization(actionId, serviceName)) {
+        qDebug() << "Authorization granted via Polkit for service:" << serviceName;
+        return true;
+    }
+
+    qWarning() << "Authorization denied for service:" << serviceName;
+    sendErrorReply(QDBusError::AccessDenied);
+    return false;
+}
+
 } // namespace DiskManager

--- a/service/diskmanagerservice.h
+++ b/service/diskmanagerservice.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -25,7 +25,7 @@ class DiskManagerService : public QObject
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "com.deepin.diskmanager")
 public:
-    explicit DiskManagerService(QObject *parent = nullptr);
+    explicit DiskManagerService(const QString &frontEndDBusName, QObject *parent = nullptr);
 
 Q_SIGNALS:
     /**
@@ -473,6 +473,8 @@ private:
      * @param 无
      */
     void initConnection();
+    bool checkAuthorization(void);
+
 signals:
     void getAllDeviceInfomation();
 
@@ -481,6 +483,7 @@ private slots:
 
 private:
     PartedCore *m_partedcore;  //磁盘操作类对象
+    QString m_frontEndDBusName;
 };
 
 } // namespace DiskManager

--- a/service/main.cpp
+++ b/service/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -27,6 +27,12 @@ int main(int argc, char *argv[])
     PATH += ":/usr/sbin";
     PATH += ":/sbin";
     qputenv("PATH", PATH.toLatin1());
+
+    QString frontEndDBusName;
+    if (argc >= 2) {
+        frontEndDBusName = QString(argv[1]);
+        qDebug() << "Received frontend DBus name:" << frontEndDBusName;
+    }
 
     QCoreApplication a(argc, argv);
     a.setOrganizationName("deepin");
@@ -58,7 +64,7 @@ int main(int argc, char *argv[])
         qCritical() << "registerService failed:" << systemBus.lastError();
         exit(0x0001);
     }
-    DiskManager::DiskManagerService service;
+    DiskManager::DiskManagerService service(frontEndDBusName);
     qDebug() << "systemBus.registerService success" /*<< Dtk::Core::DLogManager::getlogFilePath()*/;
     if (!systemBus.registerObject(DiskManagerPath,
                                   &service,

--- a/service/policy/com.deepin.diskmanager.policy
+++ b/service/policy/com.deepin.diskmanager.policy
@@ -9,7 +9,7 @@
 		<defaults>
 			<allow_any>auth_admin</allow_any>
 			<allow_inactive>auth_admin</allow_inactive>
-			<allow_active>auth_admin</allow_active>
+			<allow_active>auth_admin_keep</allow_active>
 		</defaults>
 		<annotate key="org.freedesktop.policykit.exec.path">/usr/bin/deepin-diskmanager-authenticateProxy</annotate>
 		<annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>


### PR DESCRIPTION
Replace UnixProcessSubject(PID) with SystemBusNameSubject for Polkit authorization, and add centralized checkAuthorization() to all service methods for consistent access control.

将Polkit鉴权方式从进程PID切换为DBus总线名，并在所有服务
方法中添加统一的鉴权检查，实现一致的访问控制。

Log: 将DBus鉴权方式从PID切换为总线名并统一鉴权入口
PMS: BUG-364093
Influence: 所有通过DBus调用的服务方法现在均需通过Polkit鉴权，提升系统安全性。