### PR TITLE
fix(partition): add tolerance to add button enable condition

### DIFF
--- a/application/widgets/customcontrol/partitionwidget.cpp
+++ b/application/widgets/customcontrol/partitionwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026  UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -778,7 +778,7 @@ void PartitionWidget::onSetSliderValue()
     m_block = 1;
     m_slider->setValue(static_cast<int>((value / (m_total - (sumValue() / 1024))) * 100));
     m_currentEditSize = QString::number(value * 1024, 'f', 4);
-    if (value == 0.00 || value > (m_total - sumValue() / 1024)) {
+    if (value == 0.00 || value > (m_total - sumValue() / 1024) + 0.01) {
         m_addButton->setEnabled(false);
     } else {
         m_addButton->setEnabled(true);


### PR DESCRIPTION
Add floating-point tolerance when comparing input value with remaining space to prevent disabling the add button due to precision error.

比较输入值与剩余空间时增加浮点容差，避免因精度误差错误禁用添加按钮。

Log: 修复添加按钮在边界值被错误禁用
PMS: BUG-364667
Influence: 修复后用户输入等于剩余空间时添加按钮可正常启用，提升分区创建交互体验。