### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/application/assets/deepin-diskmanager.desktop
+++ b/application/assets/deepin-diskmanager.desktop
@@ -8,5 +8,6 @@ StartupNotify=true
 TryExec=deepin-diskmanager
 Type=Application
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Automatically generate translations


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Bug Fixes:
- Mark deepin-diskmanager as a singleton application via desktop entry metadata to ensure splash screen is skipped appropriately.