### PR TITLE
chore: Update version to 6.0.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-diskmanager (6.0.27) unstable; urgency=medium
+
+  * chore: Update version to 6.0.27
+  * chore(ci): update actions/checkout to v7 and enable unsafe PR checkout
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix(partition): add tolerance to add button enable condition
+  * fix(partition): simplify redundant condition in chart drawing
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 31 Jul 2026 13:21:18 +0800
+
 deepin-diskmanager (6.0.26) unstable; urgency=medium
 
   * refactor: use QDBusServiceWatcher to detect frontend exit


### PR DESCRIPTION
- update version to 6.0.27

log: update version to 6.0.27

## Summary by Sourcery

Chores:
- Bump packaged version to 6.0.27 in Debian changelog.