### PR TITLE
fix(build): make DConfig optional for 102X-107X compatibility

### DIFF
--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -25,7 +25,10 @@ set(APP_DCONFIG_SCHEMA "${APP_DCONFIG_DIR}/com.deepin.diskmanager.storage.json")
 
 # Find the library
 find_package(PkgConfig REQUIRED)
-find_package(DtkCore REQUIRED)
+find_package(DtkCore)
+if(DtkCore_FOUND)
+    add_definitions(-DHAVE_DCONFIG)
+endif()
 find_package(DtkGui REQUIRED)
 find_package(Qt5 COMPONENTS
     Core

--- a/service/diskoperation/DeviceStorage.cpp
+++ b/service/diskoperation/DeviceStorage.cpp
@@ -8,7 +8,9 @@
 #include <QRegularExpression>
 #include <QScopedPointer>
 #include <QVariant>
+#ifdef HAVE_DCONFIG
 #include <DConfig>
+#endif
 #include "utils.h"
 
 namespace DiskManager {
@@ -588,9 +590,11 @@ static bool isPGUX()
 
 // 从 DConfig 读取需要识别为 UFS 接口的 spec_version 子串列表，新增 UFS 版本时
 // 只需在 com.deepin.diskmanager.storage 配置中追加，无需修改源码。
+// 当构建环境不支持 DConfig（如 102X 等低版本）时，回退到硬编码列表。
 static QStringList ufsSpecVersions()
 {
     const QStringList fallback{"300", "310", "400", "410"};
+#ifdef HAVE_DCONFIG
     QScopedPointer<Dtk::Core::DConfig> cfg(
         Dtk::Core::DConfig::create("com.deepin.diskmanager", "com.deepin.diskmanager.storage"));
     if (cfg && cfg->isValid()) {
@@ -598,6 +602,7 @@ static QStringList ufsSpecVersions()
         if (!versions.isEmpty())
             return versions;
     }
+#endif
     return fallback;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,10 @@ LIST(APPEND SRC_LIST ${UT_DISKOPERATION})
 file(GLOB ALL_HEADERS "../service/diskoperation/*.h" "../service/diskoperation/filesystems/*.h")
 file(GLOB ALL_SOURCES "../service/diskoperation/*.cpp" "../service/diskoperation/filesystems/*.cpp")
 
-find_package(DtkCore REQUIRED)
+find_package(DtkCore)
+if(DtkCore_FOUND)
+    add_definitions(-DHAVE_DCONFIG)
+endif()
 
 add_executable(${PROJECT_NAME_TEST} ${SRC_LIST} ${ALL_HEADERS} ${ALL_SOURCES})
 


### PR DESCRIPTION
Guard DConfig usage with HAVE_DCONFIG so builds succeed on older dtkcore versions that lack the DConfig header.

用#ifdef HAVE_DCONFIG保护DConfig调用，无DtkCore时回退到硬编码，
确保102X~107X全版本可编译。

Log: DConfig改为可选依赖，兼容低版本dtkcore
Bug: https://pms.uniontech.com/bug-view-372777.html
Influence: 解耦应用在102X~107X全版本可正常编译，低版本回退硬编码UFS版本列表。

## Summary by Sourcery

Make DConfig usage optional so the service and tests build with or without DtkCore across 102X–107X versions.

Enhancements:
- Guard DConfig-based UFS spec version lookup with HAVE_DCONFIG and fall back to a hardcoded version list when DConfig is unavailable.

Build:
- Relax DtkCore from required to optional in service and test CMake configs and define HAVE_DCONFIG only when DtkCore is found.