### PR TITLE
fix(ui): show available space instead of total capacity in size info widget

### DIFF
--- a/application/widgets/customcontrol/sizeinfowidget.cpp
+++ b/application/widgets/customcontrol/sizeinfowidget.cpp
@@ -38,11 +38,13 @@ void SizeInfoWidget::setData(PartitionInfo info, QVector<QColor> color, QVector<
     m_used = Utils::sectorToUnit(info.m_sectorsUsed, info.m_sectorSize, SIZE_UNIT::UNIT_GIB);
     m_totalSpaceSize = Utils::formatSize(info.m_sectorEnd - info.m_sectorStart + 1, info.m_sectorSize);
     m_usedSize = Utils::formatSize(info.m_sectorsUsed, info.m_sectorSize);
+    m_availableSize = Utils::formatSize(info.m_sectorsUnused, info.m_sectorSize);
 
     if (info.m_luksFlag == LUKSFlag::IS_CRYPT_LUKS) {
         LUKS_INFO luksInfo = DMDbusHandler::instance()->probLUKSInfo().m_luksMap.value(info.m_path);
         if (luksInfo.isDecrypt) {
             m_usedSize = Utils::LVMFormatSize(luksInfo.m_mapper.m_fsUsed);
+            m_availableSize = Utils::LVMFormatSize(luksInfo.m_mapper.m_fsUnused);
             m_noused = Utils::LVMSizeToUnit(luksInfo.m_mapper.m_fsUnused, SIZE_UNIT::UNIT_GIB);
             m_used = Utils::LVMSizeToUnit(luksInfo.m_mapper.m_fsUsed, SIZE_UNIT::UNIT_GIB);
         }
@@ -75,15 +77,18 @@ void SizeInfoWidget::setData(LVInfo info, QVector<QColor> color, QVector<double>
     m_used = Utils::LVMSizeToUnit(info.m_fsUsed, SIZE_UNIT::UNIT_GIB);
     m_noused = Utils::LVMSizeToUnit(info.m_fsUnused, SIZE_UNIT::UNIT_GIB);
     m_usedSize = Utils::LVMFormatSize(info.m_fsUsed);
+    m_availableSize = Utils::LVMFormatSize(info.m_fsUnused);
 
     if (info.m_luksFlag == LUKSFlag::IS_CRYPT_LUKS) {
         LUKS_INFO luksInfo = DMDbusHandler::instance()->probLUKSInfo().m_luksMap.value(info.m_lvPath);
         if (luksInfo.isDecrypt) {
             m_usedSize = Utils::LVMFormatSize(luksInfo.m_mapper.m_fsUsed);
+            m_availableSize = Utils::LVMFormatSize(luksInfo.m_mapper.m_fsUnused);
             m_noused = Utils::LVMSizeToUnit(luksInfo.m_mapper.m_fsUnused, SIZE_UNIT::UNIT_GIB);
             m_used = Utils::LVMSizeToUnit(luksInfo.m_mapper.m_fsUsed, SIZE_UNIT::UNIT_GIB);
         } else {
             m_usedSize = "-";
+            m_availableSize = "-";
         }
     }
 
@@ -116,11 +121,13 @@ void SizeInfoWidget::setData(DeviceInfo info, QVector<QColor> color, QVector<dou
     m_used = 0.00;
     m_noused = Utils::LVMSizeToUnit(info.m_length * info.m_sectorSize, SIZE_UNIT::UNIT_GIB);
     m_usedSize = Utils::LVMFormatSize(-1 * info.m_sectorSize);
+    m_availableSize = Utils::LVMFormatSize(-1 * info.m_sectorSize);
 
     if (info.m_luksFlag == LUKSFlag::IS_CRYPT_LUKS && info.m_partition.size() == 0) {
         LUKS_INFO luksInfo = DMDbusHandler::instance()->probLUKSInfo().m_luksMap.value(info.m_path);
         if (luksInfo.isDecrypt) {
             m_usedSize = Utils::LVMFormatSize(luksInfo.m_mapper.m_fsUsed);
+            m_availableSize = Utils::LVMFormatSize(luksInfo.m_mapper.m_fsUnused);
             m_noused = Utils::LVMSizeToUnit(luksInfo.m_mapper.m_fsUnused, SIZE_UNIT::UNIT_GIB);
             m_used = Utils::LVMSizeToUnit(luksInfo.m_mapper.m_fsUsed, SIZE_UNIT::UNIT_GIB);
         }
@@ -254,7 +261,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             option.setAlignment(Qt::AlignTop);
 
             QFontMetrics fmCapacity = painter.fontMetrics();
-            QString textCapacity = QString(m_partitionPath + tr(" Capacity:") + " ");
+            QString textCapacity = tr(" Available: ");
             int capacityWidth = fmCapacity.width(textCapacity);
             if (capacityWidth > rect.width() / 2) {
                 capacityWidth = rect.width() / 2;
@@ -263,7 +270,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             }
             QRect rectText = QRect(paintRect.bottomLeft().x() + 28, paintRect.bottomLeft().y() + 17, capacityWidth, 70);
             painter.drawText(rectText, textCapacity, option);
-            // 获取总容量字符串显示的宽度
+            // 获取可用空间字符串显示的宽度
             int capacityNum = rectText.x() + capacityWidth;
 
             font = DFontSizeManager::instance()->get(DFontSizeManager::T8);
@@ -272,7 +279,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             painter.setPen(text1Color);
             QTextOption option1;
             option.setAlignment(Qt::AlignLeft);
-            QRect rectSizeNum = QRect(paintRect.bottomLeft().x() + capacityNum, paintRect.bottomLeft().y() + 20, painter.fontMetrics().width(m_totalSpaceSize) + 20, 30);
+            QRect rectSizeNum = QRect(paintRect.bottomLeft().x() + capacityNum, paintRect.bottomLeft().y() + 20, painter.fontMetrics().width(m_availableSize) + 20, 30);
 
             int height2 = 21 + static_cast<int>((QApplication::font().pointSizeF() / 0.75 - 14) * 1);
             int width = roundRect.x() + capacityNum + rectSizeNum.width() + 30;
@@ -307,7 +314,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             painter.setFont(font);
             painter.setPen(text1Color);
             option.setAlignment(Qt::AlignLeft);
-            painter.drawText(rectSizeNum, m_totalSpaceSize, option1);
+            painter.drawText(rectSizeNum, m_availableSize, option1);
 
             rectSizeNum.moveTo(paintRect.bottomLeft().x() + usedNum, paintRect.bottomLeft().y() + 20);
             if (m_usedSize.contains("-")) {
@@ -338,7 +345,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             option.setAlignment(Qt::AlignTop);
 
             QFontMetrics fmCapacity = painter.fontMetrics();
-            QString textCapacity = QString(m_partitionPath + tr(" Capacity:") + " ");
+            QString textCapacity = tr(" Available: ");
             int capacityWidth = fmCapacity.width(textCapacity);
             if (capacityWidth > rect.width() / 2) {
                 capacityWidth = rect.width() / 2;
@@ -347,7 +354,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             }
             QRect rectText = QRect(paintRect.bottomLeft().x() + 28, paintRect.bottomLeft().y() + 17, capacityWidth, 70);
             painter.drawText(rectText, textCapacity, option);
-            // 获取总容量字符串显示的宽度
+            // 获取可用空间字符串显示的宽度
             int capacityNum = rectText.x() + capacityWidth;
 
             font = DFontSizeManager::instance()->get(DFontSizeManager::T8);
@@ -356,7 +363,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             painter.setPen(text1Color);
             QTextOption option1;
             option.setAlignment(Qt::AlignLeft);
-            QRect rectSizeNum = QRect(paintRect.bottomLeft().x() + capacityNum, paintRect.bottomLeft().y() + 20, painter.fontMetrics().width(m_totalSpaceSize) + 20, 30);
+            QRect rectSizeNum = QRect(paintRect.bottomLeft().x() + capacityNum, paintRect.bottomLeft().y() + 20, painter.fontMetrics().width(m_availableSize) + 20, 30);
 
             int height2 = 21 + static_cast<int>((QApplication::font().pointSizeF() / 0.75 - 14) * 1);
             int width = roundRect.x() + capacityNum + rectSizeNum.width() + 30;
@@ -390,7 +397,7 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
             painter.setFont(font);
             painter.setPen(text1Color);
             option.setAlignment(Qt::AlignLeft);
-            painter.drawText(rectSizeNum, m_totalSpaceSize, option1);
+            painter.drawText(rectSizeNum, m_availableSize, option1);
 
             rectSizeNum.moveTo(paintRect.bottomLeft().x() + usedNum, paintRect.bottomLeft().y() + 20);
             if (m_usedSize.contains("-")) {

--- a/application/widgets/customcontrol/sizeinfowidget.cpp
+++ b/application/widgets/customcontrol/sizeinfowidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-only
 

--- a/application/widgets/customcontrol/sizeinfowidget.h
+++ b/application/widgets/customcontrol/sizeinfowidget.h
@@ -93,6 +93,7 @@ private:
     DPalette m_parentPb;
     QString m_totalSpaceSize;
     QString m_usedSize;
+    QString m_availableSize;
     QString m_partitionPath;
 };
 


### PR DESCRIPTION
fix(ui): show available space instead of total capacity in size info widget

The capacity bar label in the disk/partition detail view was showing
total capacity. Per product decision, change it to show available space
(available = total - used) with the label 'Available:' instead of the
partition path + 'Capacity:'.

Log: Update capacity bar legend to display available space
Bug: https://pms.uniontech.com/bug-view-204631.html

## Summary by Sourcery

Show available space rather than total capacity in the size information widget.

Bug Fixes:
- Display available disk or partition space in the size information widget instead of total capacity.

Enhancements:
- Update the capacity bar legend to use the “Available:” label and show available-space values across partition, logical-volume, device, and decrypted LUKS views.