### PR TITLE
fix(ui): normalize invalid available size to dash in size info widget

### DIFF
--- a/application/widgets/customcontrol/sizeinfowidget.cpp
+++ b/application/widgets/customcontrol/sizeinfowidget.cpp
@@ -237,6 +237,8 @@ void SizeInfoWidget::paintEvent(QPaintEvent *event)
     //绘制首页下方标注
     if (m_flag) {
         DGuiApplicationHelper::ColorType themeType = DGuiApplicationHelper::instance()->themeType();
+        if (m_availableSize.contains("-"))
+            m_availableSize = "-";
         if (themeType == DGuiApplicationHelper::LightType) {
             int height = 90 - static_cast<int>((QApplication::font().pointSizeF() / 0.75 - 14) * 1);
             QRect roundRect = QRect(rect.bottomLeft().x() + 2, rect.bottomLeft().y() - height, 15, 15);


### PR DESCRIPTION
When m_availableSize contains a "-" (e.g. from negative value formatting), normalize it to "-" to avoid displaying invalid available space.

当可用空间值含"-"（如负值格式化结果）时，将其统一为"-"，避免显示无效的可用空间值。

Log: 修复可用空间显示含"-"的异常值
PMS: BUG-204631
Influence: 修复后分区信息中可用空间显示为"-"而非负值，避免界面显示异常。

## Summary by Sourcery

Bug Fixes:
- Normalize invalid available-size values containing a dash to display as a single dash in the size information widget.